### PR TITLE
Initialize forcFileInfo(iHRU)%ixFirstHRU to prevent seg fault (on OS X)

### DIFF
--- a/build/source/engine/ffile_info.f90
+++ b/build/source/engine/ffile_info.f90
@@ -193,11 +193,10 @@ contains
  end do  ! (looping through files describing each HRU)
  ! identify the first HRU to use a given data file
  do iHRU=1,nHRU
+  forcFileInfo(iHRU)%ixFirstHRU = 0
   do jHRU=1,iHRU-1
    if(trim(forcFileInfo(iHRU)%filenmData) == trim(forcFileInfo(jHRU)%filenmData))then
     forcFileInfo(iHRU)%ixFirstHRU = jHRU  ! index of first HRU to share the same data
-   else
-    forcFileInfo(iHRU)%ixFirstHRU = 0
    endif
   end do
  end do


### PR DESCRIPTION
Modified logic to ensure that `forcFileInfo(iHRU)%ixFirstHRU` is always initialized. 

On OS X SUMMA produced the following error:

`Program received signal SIGSEGV: Segmentation fault - invalid memory reference.`

in read_force.f90, because `forcFileInfo(iHRU)%ixFirstHRU` could be a large value and `time_hru(forcFileInfo(iHRU)%ixFirstHRU)` would be an invalid memory location.

@martynpclark : Please make sure that this change makes sense and does not change the intended behavior. Also rerun your tests to ensure that results are unchanged.
