### PR TITLE
Feature/docs

### DIFF
--- a/docs/howto/summa_and_git_howto.md
+++ b/docs/howto/summa_and_git_howto.md
@@ -18,7 +18,7 @@ In general, if you plan to apply the model rather than work directly on the sour
 If you plan on contributing to model development or would like a systematic way to incorporate updates to the SUMMA source code, we encourage you to use Git. The following sections are designed to get you started using Git and working with the SUMMA source code repository.
 
 ### Git resources
-If you are SUMMA familiar with Git yet, we encourage you to spend a few minutes getting antiquated with the system before you starting working with the SUMMA source code and Git. It's not difficult to use and a few minutes of learning about Git will go along way in helping you manage your code development.
+If you are not familiar with Git yet, we encourage you to spend a few minutes getting acquainted with the system before you starting working with the SUMMA source code and Git. It's not difficult to use and a few minutes of learning about Git will go along way in helping you manage your code development.
 
 There are a number of good Git learning resources that will provide a basic introduction to the version control system.
 * http://git-scm.com/about
@@ -84,7 +84,7 @@ then you are not in a Git repository (note that the top level directory in a Git
 
 Assign the truth repo to a remote tracking branch called `upstream`, which will allow you easily pull in changes that are made in the truth repo and keep your clone in-sync with that version. Once you get more familiar with Git, you will be able to control which updates to include:
 
-    git remote add --tracking upstream https://github.com/NCAR/summa.git
+    git remote add upstream https://github.com/NCAR/summa.git
 
 #### Step 4. Sync your clone with the truth repo
 
@@ -189,7 +189,7 @@ The SUMMA administrator and other developers will review your pull request and d
 
 ### Git workflow
 
-For us to leverage Git to its full potential, we have implemented a Git-oriented workflow. This requires developers to adhere to a few rules regarding branch names and merge requests. A full description of the workflow we use can be found [here](https://github.com/NCAR/summa/docs/summa_git_workflow.md).
+For us to leverage Git to its full potential, we have implemented a Git-oriented workflow. This requires developers to adhere to a few rules regarding branch names and merge requests. A full description of the workflow we use can be found [here](https://github.com/NCAR/summa/blob/master/docs/howto/summa_git_workflow.md).
 
 
 

--- a/docs/howto/summa_git_workflow.md
+++ b/docs/howto/summa_git_workflow.md
@@ -36,9 +36,9 @@ Although anyone could create these branches, they are designed for the preparati
  * Feature branch – feature/{feature_name}
  * Hotfix branch – hotfix/{hotfix_name}
  * Release branch – release/{release_name}
- * Support branch – support/VIC.{base_release_number}.{feature_branch_name}
- * Release name – VIC.{major.minor.patch}
- * Support release name - VIC.{base_release_number}.{feature_branch_name}.{##}
+ * Support branch – support/SUMMA.{base_release_number}.{feature_branch_name}
+ * Release name – SUMMA.{major.minor.patch}
+ * Support release name - SUMMA.{base_release_number}.{feature_branch_name}.{##}
 
 ## User Permissions
 Using Github to host the central or truth repository of our models allows us to easily control contributor permissions. Currently we split permission levels into 3 levels, Owners, Model Admins, and Developers.
@@ -47,7 +47,7 @@ Using Github to host the central or truth repository of our models allows us to 
 
  2. Model Admins have full access to specific repositories. They may push, pull, or make administrative changes to those repositories associated with their model. However, they should generally not push to the truth repo directly. Instead, they should fork, clone, edit locally, update their fork and then issue a pull request. This pull request should preferably be reviewed by someone else before it is merged.
 
- 3. Developers have read-only access (pull, clone, fork) to any of the publically listed repositories under the UW-hydro name. If a developer would like a feature branch merged into the main repository, a pull request must be submitted and a Model Admin may merge it in.
+ 3. Developers have read-only access (pull, clone, fork) to any of the publicly listed repositories under the UW-hydro name. If a developer would like a feature branch merged into the main repository, a pull request must be submitted and a Model Admin may merge it in.
 
 ## Workflow examples
 
@@ -67,7 +67,7 @@ The process would be as follows:
 
  * Add the main SUMMA repo as the upstream remote, so you can easily merge changes that are made in the main SUMMA repo into your own local repo
 
-        git add remote upstream git@github.com:NCAR/summa.git
+        git remote add upstream git@github.com:NCAR/summa.git
 
  * Checkout the `develop` branch
 
@@ -81,7 +81,7 @@ The process would be as follows:
 
         git push
 
- * Now make as many changes as you need to, commit them to your local repo and push them to your remote on GitHub. This is just like any other work you would do using Git. Once everything is working and eevrything is sufficiently tested, you will be ready to share your code with others.
+ * Now make as many changes as you need to, commit them to your local repo and push them to your remote on GitHub. This is just like any other work you would do using Git. Once everything is working and everything is sufficiently tested, you will be ready to share your code with others.
 
 
  * Before you do that, merge any changes that have been made in the develop branch in the main SUMMA repo into the `feature/resistance` branch of your local repo. Assuming you are already on the `feature/resistance` branch:


### PR DESCRIPTION
Fixed typos in summa_and_git_howto.md and in summa_git_workflow.md

In summa_and_git_howto.md: 
Line 87: The --track command requires a branch to be specified. I'm not sure if you meant to specify a branch here or add all upstream branches. 
Line 192: Corrected the link to summa_git_workflow.md

In summa_git_workflow.md:
Line 70: fixed order of "add" and "remote"