### PR TITLE
Minor changes to git documentation

### DIFF
--- a/docs/howto/summa_and_git_howto.md
+++ b/docs/howto/summa_and_git_howto.md
@@ -189,7 +189,7 @@ The SUMMA administrator and other developers will review your pull request and d
 
 ### Git workflow
 
-For us to leverage Git to its full potential, we have implemented a Git-oriented workflow. This requires developers to adhere to a few rules regarding branch names and merge requests. A full description of the workflow we use can be found [here](https://github.com/NCAR/summa/docs/summa_git_workflow.md).
+For us to leverage Git to its full potential, we have implemented a Git-oriented workflow. This requires developers to adhere to a few rules regarding branch names and merge requests. A full description of the workflow we use can be found [here](https://github.com/NCAR/summa/blob/master/docs/howto/summa_git_workflow.md).
 
 
 

--- a/docs/howto/summa_git_workflow.md
+++ b/docs/howto/summa_git_workflow.md
@@ -36,9 +36,9 @@ Although anyone could create these branches, they are designed for the preparati
  * Feature branch – feature/{feature_name}
  * Hotfix branch – hotfix/{hotfix_name}
  * Release branch – release/{release_name}
- * Support branch – support/VIC.{base_release_number}.{feature_branch_name}
- * Release name – VIC.{major.minor.patch}
- * Support release name - VIC.{base_release_number}.{feature_branch_name}.{##}
+ * Support branch – support/SUMMA.{base_release_number}.{feature_branch_name}
+ * Release name – SUMMA.{major.minor.patch}
+ * Support release name - SUMMA.{base_release_number}.{feature_branch_name}.{##}
 
 ## User Permissions
 Using Github to host the central or truth repository of our models allows us to easily control contributor permissions. Currently we split permission levels into 3 levels, Owners, Model Admins, and Developers.
@@ -47,7 +47,7 @@ Using Github to host the central or truth repository of our models allows us to 
 
  2. Model Admins have full access to specific repositories. They may push, pull, or make administrative changes to those repositories associated with their model. However, they should generally not push to the truth repo directly. Instead, they should fork, clone, edit locally, update their fork and then issue a pull request. This pull request should preferably be reviewed by someone else before it is merged.
 
- 3. Developers have read-only access (pull, clone, fork) to any of the publically listed repositories under the UW-hydro name. If a developer would like a feature branch merged into the main repository, a pull request must be submitted and a Model Admin may merge it in.
+ 3. Developers have read-only access (pull, clone, fork) to any of the publically listed repositories under the NCAR name. If a developer would like a feature branch merged into the main repository, a pull request must be submitted and a Model Admin may merge it in.
 
 ## Workflow examples
 

--- a/docs/howto/summa_git_workflow.md
+++ b/docs/howto/summa_git_workflow.md
@@ -67,7 +67,7 @@ The process would be as follows:
 
  * Add the main SUMMA repo as the upstream remote, so you can easily merge changes that are made in the main SUMMA repo into your own local repo
 
-        git add remote upstream git@github.com:NCAR/summa.git
+        git remote add upstream git@github.com:NCAR/summa.git
 
  * Checkout the `develop` branch
 


### PR DESCRIPTION
3 fixes:
1) Fixed the link from git howto doc to git workflow doc. 
2) Changed 'git add remote' to 'git remote add' (does git add remote work on some other version of git?)
3) Removed various residual references to VIC and UW-hydro in the git workflow doc. 
