### PR TITLE
improve convergence by including derivatives of ground evap w.r.t. relevant state variables

### DIFF
--- a/build/source/driver/multi_driver.f90
+++ b/build/source/driver/multi_driver.f90
@@ -150,6 +150,7 @@ real(dp)                  :: fracHRU                        ! fractional area of
 real(dp),allocatable      :: zSoilReverseSign(:)            ! height at bottom of each soil layer, negative downwards (m)
 real(dp),dimension(12)    :: greenVegFrac_monthly           ! fraction of green vegetation in each month (0-1)
 real(dp),parameter        :: doubleMissing=-9999._dp        ! missing value
+logical(lgt),parameter    :: overwriteRSMIN=.false.         ! flag to overwrite RSMIN
 ! error control
 integer(i4b)              :: err=0                          ! error code
 character(len=1024)       :: message=''                     ! error message
@@ -380,6 +381,9 @@ do istep=1,numtim
   call read_force(istep,iHRU,err,message); call handle_err(err,message)
  end do  ! (end looping through HRUs)
 
+ ! print progress
+ if(time_data%var(iLookTIME%ih) == 1) write(*,'(i4,1x,5(i2,1x))') time_data%var
+
  ! *****************************************************************************
  ! (7) create a new NetCDF output file, and write parameters and forcing data
  ! *****************************************************************************
@@ -476,7 +480,7 @@ do istep=1,numtim
               urbanVegCategory)                                                  ! vegetation category for urban areas
 
   ! overwrite the minimum resistance
-  !RSMIN = mpar_data%var(iLookPARAM%minStomatalResistance)
+  if(overwriteRSMIN) RSMIN = mpar_data%var(iLookPARAM%minStomatalResistance)
 
   ! overwrite the vegetation height
   HVT(type_data%var(iLookTYPE%vegTypeIndex)) = mpar_data%var(iLookPARAM%heightCanopyTop)
@@ -601,7 +605,7 @@ do istep=1,numtim
  ! increment the time index
  jstep = jstep+1
 
- !pause 'in driver: testing differences'
+ !print*, 'PAUSE: in driver: testing differences'; read(*,*)
  !stop 'end of time step'
 
 end do  ! (looping through time)

--- a/build/source/engine/coupled_em.f90
+++ b/build/source/engine/coupled_em.f90
@@ -99,7 +99,6 @@ contains
  real(dp),parameter                   :: F_inc = 1.25_dp        ! factor used to increase time step
  real(dp),parameter                   :: F_dec = 0.90_dp        ! factor used to decrease time step
  integer(i4b)                         :: maxiter                ! maxiumum number of iterations
- integer(i4b)                         :: iSnow                  ! index for snow layers
  ! check SWE
  real(dp)                             :: oldSWE                 ! SWE at the start of the substep
  real(dp)                             :: newSWE                 ! SWE at the end of the substep
@@ -114,7 +113,6 @@ contains
  character(len=256)                   :: cmessage               ! error message
  logical(lgt)                         :: computeVegFlux         ! flag to indicate if we are computing fluxes over vegetation (.false. means veg is buried with snow)
  integer(i4b)                         :: nLayersRoots           ! number of soil layers that contain roots
- real(dp)                             :: scalarCanopyWater      ! total canopy water (kg m-2)
  real(dp)                             :: canopyDepth            ! canopy depth (m)
  real(dp)                             :: exposedVAI             ! exposed vegetation area index
  real(dp)                             :: dt_wght                ! weight applied to each sub-step, to compute time step average
@@ -132,6 +130,7 @@ contains
  integer(i4b)                         :: nTemp                  ! number of temporary sub-steps
  integer(i4b)                         :: nTrial                 ! number of trial sub-steps
  logical(lgt)                         :: rejectedStep           ! flag to denote if the sub-step is rejected (convergence problem, etc.)
+ logical(lgt),parameter               :: checkTimeStepping=.false.  ! flag to denote a desire to check the time stepping 
  ! balance checks
  real(dp),pointer                     :: scalarSnowfall         ! snowfall rate
  real(dp),pointer                     :: scalarRainfall         ! rainfall rate
@@ -749,11 +748,13 @@ contains
    dt_wght = dt_temp/dt ! define weight applied to each sub-step
    call increment_fluxes(dt_wght,(nsub==1 .and. ntemp==1))
 
-   !dt_prog = dt_done+dt_solv+dt_temp  ! progress in time step (s)
-   !dt_frac = dt_prog/dt               ! fraction of time step completed (-)
-   !write(*,'(a,1x,3(f9.3,1x),10(e20.10,1x))') 'dt_wght, dt_prog, dt_frac, totalSoilCompress, dt_prog*averageSoilInflux/dt_frac, scalarSoilCompress, scalarSoilInflux*dt_temp = ', &
-   !                                            dt_wght, dt_prog, dt_frac, totalSoilCompress, dt_prog*averageSoilInflux/dt_frac, scalarSoilCompress, mvar_data%var(iLookMVAR%iLayerLiqFluxSoil)%dat(0)*dt_temp
-   !pause
+   ! check time stepping
+   if(checkTimestepping)then
+    dt_prog = dt_done+dt_solv+dt_temp  ! progress in time step (s)
+    dt_frac = dt_prog/dt               ! fraction of time step completed (-)
+    write(*,'(a,1x,3(f9.3,1x),10(e20.10,1x))') 'dt_wght, dt_prog, dt_frac = ', &
+                                                dt_wght, dt_prog, dt_frac
+   endif
 
    ! compute effective rainfall input and snowpack drainage to/from the snowpack (kg m-2 s-1)
    if(nSnow > 0)then
@@ -1181,7 +1182,6 @@ contains
  character(len=256),parameter    :: filepref='summaRestart'  ! prefix for the restart filename
  character(len=256)              :: timeString          ! string to define the time
  character(len=256)              :: filename            ! name of the restart file
- character(len=256)              :: cmessage            ! error message of downstream routine
  integer(i4b)                    :: iLayer              ! index of the model layer
  real(dp),parameter              :: valueMissing=-999._dp  ! missing value
  ! --------------------------------------------------------------------------------------------------------

--- a/build/source/engine/soilLiqFlx.f90
+++ b/build/source/engine/soilLiqFlx.f90
@@ -178,7 +178,6 @@ contains
                         ! input: model decisions
                         model_decisions(iLookDECISIONS%fDerivMeth)%iDecision,          & ! intent(in): index of the method used to calculate flux derivatives
                         model_decisions(iLookDECISIONS%f_Richards)%iDecision,          & ! intent(in): index of the form of Richards' equation
-                        model_decisions(iLookDECISIONS%hc_Profile)%iDecision,          & ! intent(in): index of the option for the hydraulic conductivity profile
                         model_decisions(iLookDECISIONS%bcUpprSoiH)%iDecision,          & ! intent(in): index of the upper boundary conditions for soil hydrology
                         model_decisions(iLookDECISIONS%bcLowrSoiH)%iDecision,          & ! intent(in): index of the lower boundary conditions for soil hydrology
 
@@ -219,13 +218,10 @@ contains
                         mpar_data%var(iLookPARAM%theta_sat),                           & ! intent(in): soil porosity (-)
                         mpar_data%var(iLookPARAM%theta_res),                           & ! intent(in): soil residual volumetric water content (-)
                         mpar_data%var(iLookPARAM%wettingFrontSuction),                 & ! intent(in): Green-Ampt wetting front suction (m)
-                        mpar_data%var(iLookPARAM%fieldCapacity),                       & ! intent(in): field capacity (-)
                         mpar_data%var(iLookPARAM%rootingDepth),                        & ! intent(in): rooting depth (m)
                         mpar_data%var(iLookPARAM%kAnisotropic),                        & ! intent(in): anisotropy factor for lateral hydraulic conductivity (-)
                         mpar_data%var(iLookPARAM%zScale_TOPMODEL),                     & ! intent(in): TOPMODEL scaling factor (m)
                         mpar_data%var(iLookPARAM%qSurfScale),                          & ! intent(in): scaling factor in the surface runoff parameterization (-)
-                        mpar_data%var(iLookPARAM%specificYield),                       & ! intent(in): specific yield (-)
-                        mpar_data%var(iLookPARAM%specificStorage),                     & ! intent(in): specific storage coefficient (m-1)
                         mpar_data%var(iLookPARAM%f_impede),                            & ! intent(in): ice impedence factor (-)
                         mpar_data%var(iLookPARAM%soilIceScale),                        & ! intent(in): scaling factor for depth of soil ice, used to get frozen fraction (m)
                         mpar_data%var(iLookPARAM%soilIceCV),                           & ! intent(in): CV of depth of soil ice, used to get frozen fraction (-)
@@ -290,7 +286,6 @@ contains
                               ! model decisions
                               ixDerivMethod,               & ! intent(in): choice of method used to compute derivative
                               ixRichards,                  & ! intent(in): choice of the form of Richards' equation
-                              hc_Profile,                  & ! intent(in): index defining the option for the hydraulic conductivity profile
                               ixBcUpperSoilHydrology,      & ! intent(in): choice of upper boundary condition for soil hydrology
                               ixBcLowerSoilHydrology,      & ! intent(in): choice of lower boundary condition for soil hydrology
 
@@ -331,13 +326,10 @@ contains
                               theta_sat,                   & ! intent(in): soil porosity (-)
                               theta_res,                   & ! intent(in): soil residual volumetric water content (-)
                               wettingFrontSuction,         & ! intent(in): Green-Ampt wetting front suction (m)
-                              fieldCapacity,               & ! intent(in): field capacity (-)
                               rootingDepth,                & ! intent(in): rooting depth (m)
                               kAnisotropic,                & ! intent(in): anisotropy factor for lateral hydraulic conductivity (-)
                               zScale_TOPMODEL,             & ! intent(in): TOPMODEL scaling factor (m)
                               qSurfScale,                  & ! intent(in): scaling factor in the surface runoff parameterization (-)
-                              specificYield,               & ! intent(in): specific yield (-)
-                              specificStorage,             & ! intent(in): specific storage coefficient (m-1)
                               f_impede,                    & ! intent(in): ice impedence factor (-)
                               soilIceScale,                & ! intent(in): scaling factor for depth of soil ice, used to get frozen fraction (m)
                               soilIceCV,                   & ! intent(in): CV of depth of soil ice, used to get frozen fraction (-)
@@ -397,7 +389,6 @@ contains
  ! input: model decisions
  integer(i4b),intent(in)          :: ixDerivMethod                ! choice of method used to compute derivative
  integer(i4b),intent(in)          :: ixRichards                   ! choice of the form of Richards' equation
- integer(i4b),intent(in)          :: hc_profile                   ! choice of type of hydraulic conductivity profile
  integer(i4b),intent(in)          :: ixBcUpperSoilHydrology       ! choice of upper boundary condition for soil hydrology
  integer(i4b),intent(in)          :: ixBcLowerSoilHydrology       ! choice of lower boundary condition for soil hydrology
  ! input: trial model state variables
@@ -431,13 +422,10 @@ contains
  real(dp),intent(in)              :: theta_sat                    ! soil porosity (-)
  real(dp),intent(in)              :: theta_res                    ! soil residual volumetric water content (-)
  real(dp),intent(in)              :: wettingFrontSuction          ! Green-Ampt wetting front suction (m)
- real(dp),intent(in)              :: fieldCapacity                ! field capacity (-)
  real(dp),intent(in)              :: rootingDepth                 ! rooting depth (m)
  real(dp),intent(in)              :: kAnisotropic                 ! anisotropy factor for lateral hydraulic conductivity (-)
  real(dp),intent(in)              :: zScale_TOPMODEL              ! TOPMODEL scaling factor (m)
  real(dp),intent(in)              :: qSurfScale                   ! scaling factor in the surface runoff parameterization (-)
- real(dp),intent(in)              :: specificYield                ! specific yield (-)
- real(dp),intent(in)              :: specificStorage              ! specific storage coefficient (m-1)
  real(dp),intent(in)              :: f_impede                     ! ice impedence factor (-)
  real(dp),intent(in)              :: soilIceScale                 ! scaling factor for depth of soil ice, used to get frozen fraction (m)
  real(dp),intent(in)              :: soilIceCV                    ! CV of depth of soil ice, used to get frozen fraction (-)
@@ -701,9 +689,6 @@ contains
                   upperBoundTheta,                    & ! intent(in): upper boundary condition (-)
                   ! input: flux at the upper boundary
                   scalarRainPlusMelt,                 & ! intent(in): rain plus melt (m s-1)
-                  ! input: derivative in soil water characteristix
-                  mLayerdPsi_dTheta(1),               & ! intent(in): derivative of the soil moisture characteristic w.r.t. theta (m)
-                  mLayerdTheta_dPsi(1),               & ! intent(in): derivative of the soil moisture characteristic w.r.t. psi (m-1)
                   ! input: transmittance
                   iLayerSatHydCond(0),                & ! intent(in): saturated hydraulic conductivity at the surface (m s-1)
                   dHydCond_dTemp(1),                  & ! intent(in): derivative in hydraulic conductivity w.r.t temperature (m s-1 K-1)
@@ -956,7 +941,6 @@ contains
                   ! input: model control
                   desireAnal,                      & ! intent(in): flag indicating if derivatives are desired
                   ixRichards,                      & ! intent(in): index defining the form of Richards' equation (moisture or mixdform)
-                  hc_profile,                      & ! intent(in): index defining the decrease of hydraulic conductivity with depth
                   ixBcLowerSoilHydrology,          & ! intent(in): index defining the type of boundary conditions
                   ! input: state variables
                   scalarMatricHeadTrial,           & ! intent(in): matric head in the lowest unsaturated node (m)
@@ -969,7 +953,6 @@ contains
                   lowerBoundTheta,                 & ! intent(in): lower boundary condition (-)
                   ! input: derivative in the soil water characteristic
                   mLayerdPsi_dTheta(nSoil),        & ! intent(in): derivative in the soil water characteristic
-                  mLayerdTheta_dPsi(nSoil),        & ! intent(in): derivative in the soil water characteristic
                   ! input: transmittance
                   iLayerSatHydCond(0),             & ! intent(in): saturated hydraulic conductivity at the surface (m s-1)
                   iLayerSatHydCond(nSoil),         & ! intent(in): saturated hydraulic conductivity at the bottom of the unsaturated zone (m s-1)
@@ -987,7 +970,6 @@ contains
                   theta_res,                       & ! intent(in): soil residual volumetric water content (-)
                   kAnisotropic,                    & ! intent(in): anisotropy factor for lateral hydraulic conductivity (-)
                   zScale_TOPMODEL,                 & ! intent(in): TOPMODEL scaling factor (m)
-                  specificYield,                   & ! intent(in): specific yield (-)
                   ! output: hydraulic conductivity and diffusivity at the surface
                   iLayerHydCond(nSoil),            & ! intent(out): hydraulic conductivity at the bottom of the unsatuarted zone (m s-1)
                   iLayerDiffuse(nSoil),            & ! intent(out): hydraulic diffusivity at the bottom of the unsatuarted zone (m2 s-1)
@@ -1143,9 +1125,9 @@ contains
  real(dp)                      :: dK_dLiq__noIce            ! derivative in hydraulic conductivity w.r.t volumetric liquid water content, in the absence of ice (m s-1)
  real(dp)                      :: dK_dPsi__noIce            ! derivative in hydraulic conductivity w.r.t matric head, in the absence of ice (s-1)
  real(dp)                      :: relSatMP                  ! relative saturation of macropores (-)
- !real(dp)                      :: xConst,vTheta,volLiq,volIce,x1,x2,d1,d2,effSat,psiLiq,dEff,dPsi,hydCon,hydIce   ! test derivative
- !real(dp)                      :: x1,x2                     ! trial values of theta (-)
- !real(dp),parameter            :: dx = 1.e-8_dp             ! finite difference increment (m)
+ logical(lgt),parameter        :: testDeriv=.false.         ! local flag to test the derivative
+ real(dp)                      :: xConst,vTheta,volLiq,volIce,x1,x2,effSat,psiLiq,hydCon,hydIce   ! test derivative
+ real(dp),parameter            :: dx = 1.e-8_dp             ! finite difference increment (m)
  ! initialize error control
  err=0; message="diagv_node/"
 
@@ -1157,11 +1139,12 @@ contains
    scalardTheta_dPsi = valueMissing  ! (deliberately cause problems if this is ever used)
   case(mixdform)
    scalardTheta_dPsi = dTheta_dPsi(scalarMatricHeadTrial,vGn_alpha,theta_res,theta_sat,vGn_n,vGn_m)
-   !x1 = volFracLiq(scalarMatricHeadTrial,   vGn_alpha,theta_res,theta_sat,vGn_n,vGn_m)
-   !x2 = volFracLiq(scalarMatricHeadTrial+dx,vGn_alpha,theta_res,theta_sat,vGn_n,vGn_m)
-   !print*, 'scalardTheta_dPsi = ', scalardTheta_dPsi, (x2 - x1)/dx
-   !scalardPsi_dTheta = valueMissing  ! (deliberately cause problems if this is ever used)
    scalardPsi_dTheta = dPsi_dTheta(scalarvolFracLiqTrial,vGn_alpha,theta_res,theta_sat,vGn_n,vGn_m)
+   if(testDeriv)then
+    x1 = volFracLiq(scalarMatricHeadTrial,   vGn_alpha,theta_res,theta_sat,vGn_n,vGn_m)
+    x2 = volFracLiq(scalarMatricHeadTrial+dx,vGn_alpha,theta_res,theta_sat,vGn_n,vGn_m)
+    print*, 'scalardTheta_dPsi = ', scalardTheta_dPsi, (x2 - x1)/dx
+   endif  ! (testing the derivative)
   case default; err=10; message=trim(message)//"unknown form of Richards' equation"; return
  end select
 
@@ -1235,19 +1218,21 @@ contains
     ! (compute derivative in hydraulic conductivity w.r.t. temperature)
     dHydCond_dTemp = hydCond_noIce*dIceImpede_dT + dHydCondMicro_dTemp*iceImpedeFac
     ! (test derivative)
-    !xConst = LH_fus/(gravity*Tfreeze)                            ! m K-1 (NOTE: J = kg m2 s-2)
-    !vTheta = scalarVolFracIceTrial + scalarVolFracLiqTrial
-    !volLiq = volFracLiq(xConst*(scalarTempTrial+dx - Tfreeze),vGn_alpha,theta_res,theta_sat,vGn_n,vGn_m)
-    !volIce = vTheta - volLiq
-    !effSat = (volLiq - theta_res) / (theta_sat - volIce - theta_res)
-    !psiLiq = matricHead(effSat,vGn_alpha,0._dp,1._dp,vGn_n,vGn_m)  ! use effective saturation, so theta_res=0 and theta_sat=1
-    !hydCon = hydCond_psi(psiLiq,scalarSatHydCond,vGn_alpha,vGn_n,vGn_m)
-    !call iceImpede(volIce,f_impede,iceImpedeFac,dIceImpede_dLiq)
-    !hydIce = hydCon*iceImpedeFac
-    !print*, 'test derivative: ', (psiLiq - scalarMatricHeadTrial)/dx, dPsiLiq_dTemp
-    !print*, 'test derivative: ', (hydCon - hydCond_noIce)/dx, dHydCondMicro_dTemp
-    !print*, 'test derivative: ', (hydIce - scalarHydCond)/dx, dHydCond_dTemp
-    !pause
+    if(testDeriv)then
+     xConst = LH_fus/(gravity*Tfreeze)                            ! m K-1 (NOTE: J = kg m2 s-2)
+     vTheta = scalarVolFracIceTrial + scalarVolFracLiqTrial
+     volLiq = volFracLiq(xConst*(scalarTempTrial+dx - Tfreeze),vGn_alpha,theta_res,theta_sat,vGn_n,vGn_m)
+     volIce = vTheta - volLiq
+     effSat = (volLiq - theta_res) / (theta_sat - volIce - theta_res)
+     psiLiq = matricHead(effSat,vGn_alpha,0._dp,1._dp,vGn_n,vGn_m)  ! use effective saturation, so theta_res=0 and theta_sat=1
+     hydCon = hydCond_psi(psiLiq,scalarSatHydCond,vGn_alpha,vGn_n,vGn_m)
+     call iceImpede(volIce,f_impede,iceImpedeFac,dIceImpede_dLiq)
+     hydIce = hydCon*iceImpedeFac
+     print*, 'test derivative: ', (psiLiq - scalarMatricHeadTrial)/dx, dPsiLiq_dTemp
+     print*, 'test derivative: ', (hydCon - hydCond_noIce)/dx, dHydCondMicro_dTemp
+     print*, 'test derivative: ', (hydIce - scalarHydCond)/dx, dHydCond_dTemp
+     print*, 'press any key to continue'; read(*,*) ! (alternative to the deprecated 'pause' statement)
+    endif  ! testing the derivative
     ! (set values that are not used to missing)
     dHydCond_dVolLiq = valueMissing ! not used, so cause problems
     dDiffuse_dVolLiq = valueMissing ! not used, so cause problems
@@ -1291,9 +1276,6 @@ contains
                        upperBoundTheta,           & ! intent(in): upper boundary condition (-)
                        ! input: flux at the upper boundary
                        scalarRainPlusMelt,        & ! intent(in): rain plus melt (m s-1)
-                       ! input: derivative in soil water characteristix
-                       scalardPsi_dTheta,         & ! intent(in): derivative of the soil moisture characteristic w.r.t. theta (m)
-                       scalardTheta_dPsi,         & ! intent(in): derivative of the soil moisture characteristic w.r.t. psi (m-1)
                        ! input: transmittance
                        surfaceSatHydCond,         & ! intent(in): saturated hydraulic conductivity at the surface (m s-1)
                        dHydCond_dTemp,            & ! intent(in): derivative in hydraulic conductivity w.r.t temperature (m s-1 K-1)
@@ -1352,9 +1334,6 @@ contains
  real(dp),intent(in)           :: upperBoundTheta           ! upper boundary condition for volumetric liquid water content (-)
  ! input: flux at the upper boundary
  real(dp),intent(in)           :: scalarRainPlusMelt        ! rain plus melt, used as input to the soil zone before computing surface runoff (m s-1)
- ! input: derivative in soil water characteristix
- real(dp),intent(in)           :: scalardPsi_dTheta         ! derivative of the soil moisture characteristic w.r.t. theta (m)
- real(dp),intent(in)           :: scalardTheta_dPsi         ! derivative of the soil moisture characteristic w.r.t. psi (m-1)
  ! input: transmittance
  real(dp),intent(in)           :: surfaceSatHydCond         ! saturated hydraulic conductivity at the surface (m s-1)
  real(dp),intent(in)           :: dHydCond_dTemp            ! derivative in hydraulic conductivity w.r.t temperature (m s-1 K-1)
@@ -1720,7 +1699,6 @@ contains
                        ! input: model control
                        deriv_desired,             & ! intent(in): flag indicating if derivatives are desired
                        ixRichards,                & ! intent(in): index defining the form of Richards' equation (moisture or mixdform)
-                       hc_profile,                & ! intent(in): index defining the decrease of hydraulic conductivity with depth
                        bc_lower,                  & ! intent(in): index defining the type of boundary conditions
                        ! input: state variables
                        nodeMatricHead,            & ! intent(in): matric head in the lowest unsaturated node (m)
@@ -1733,7 +1711,6 @@ contains
                        lowerBoundTheta,           & ! intent(in): lower boundary condition (-)
                        ! input: derivative in soil water characteristix
                        node__dPsi_dTheta,         & ! intent(in): derivative of the soil moisture characteristic w.r.t. theta (m)
-                       node__dTheta_dPsi,         & ! intent(in): derivative of the soil moisture characteristic w.r.t. psi (m-1)
                        ! input: transmittance
                        surfaceSatHydCond,         & ! intent(in): saturated hydraulic conductivity at the surface (m s-1)
                        bottomSatHydCond,          & ! intent(in): saturated hydraulic conductivity at the bottom of the unsaturated zone (m s-1)
@@ -1751,7 +1728,6 @@ contains
                        theta_res,                 & ! intent(in): soil residual volumetric water content (-)
                        kAnisotropic,              & ! intent(in): anisotropy factor for lateral hydraulic conductivity (-)
                        zScale_TOPMODEL,           & ! intent(in): TOPMODEL scaling factor (m)
-                       specificYield,             & ! intent(in): drainable porosity (-)
                        ! output: hydraulic conductivity and diffusivity at the surface
                        bottomHydCond,             & ! intent(out): hydraulic conductivity at the bottom of the unsatuarted zone (m s-1)
                        bottomDiffuse,             & ! intent(out): hydraulic diffusivity at the bottom of the unsatuarted zone (m2 s-1)
@@ -1773,7 +1749,6 @@ contains
  ! input: model control
  logical(lgt),intent(in)       :: deriv_desired             ! flag to indicate if derivatives are desired
  integer(i4b),intent(in)       :: ixRichards                ! index defining the option for Richards' equation (moisture or mixdform)
- integer(i4b),intent(in)       :: hc_profile                ! index defining the decrease of hydraulic conductivity with depth
  integer(i4b),intent(in)       :: bc_lower                  ! index defining the type of boundary conditions
  ! input: state and diagnostic variables
  real(dp),intent(in)           :: nodeMatricHead            ! matric head in the lowest unsaturated node (m)
@@ -1786,7 +1761,6 @@ contains
  real(dp),intent(in)           :: lowerBoundTheta           ! lower boundary condition for volumetric liquid water content (-)
  ! input: derivative in soil water characteristix
  real(dp),intent(in)           :: node__dPsi_dTheta         ! derivative of the soil moisture characteristic w.r.t. theta (m)
- real(dp),intent(in)           :: node__dTheta_dPsi         ! derivative of the soil moisture characteristic w.r.t. psi (m-1)
  ! input: transmittance
  real(dp),intent(in)           :: surfaceSatHydCond         ! saturated hydraulic conductivity at the surface (m s-1)
  real(dp),intent(in)           :: bottomSatHydCond          ! saturated hydraulic conductivity at the bottom of the unsaturated zone (m s-1)
@@ -1804,7 +1778,6 @@ contains
  real(dp),intent(in)           :: theta_res                 ! soil residual volumetric water content (-)
  real(dp),intent(in)           :: kAnisotropic              ! anisotropy factor for lateral hydraulic conductivity (-)
  real(dp),intent(in)           :: zScale_TOPMODEL           ! scale factor for TOPMODEL-ish baseflow parameterization (m)
- real(dp),intent(in)           :: specificYield             ! specific yield (-)
  ! -----------------------------------------------------------------------------------------------------------------------------
  ! output: hydraulic conductivity at the bottom of the unsaturated zone
  real(dp),intent(out)          :: bottomHydCond             ! hydraulic conductivity at the bottom of the unsaturated zone (m s-1)

--- a/build/source/engine/stomResist.f90
+++ b/build/source/engine/stomResist.f90
@@ -87,7 +87,6 @@ contains
                        scalarVP_CanopyAir,                  & ! intent(in): canopy air vapor pressure (Pa)
                        ! input: data structures
                        type_data,                           & ! intent(in):    type of vegetation and soil
-                       attr_data,                           & ! intent(in):    spatial attributes
                        forc_data,                           & ! intent(in):    model forcing data
                        mpar_data,                           & ! intent(in):    model parameters
                        model_decisions,                     & ! intent(in):    model decisions
@@ -103,8 +102,6 @@ contains
                      var_d,            & ! data vector (dp)
                      var_dlength,      & ! data vector with variable length dimension (dp)
                      model_options       ! defines the model decisions
- ! provide access to the output directory
- USE summaFileManager,only:OUTPUT_PATH,OUTPUT_PREFIX         ! define output file
  ! provide access to named variables defining elements in the data structures
  USE var_lookup,only:iLookTIME,iLookTYPE,iLookATTR,iLookFORCE,iLookPARAM,iLookMVAR,iLookBVAR,iLookINDEX  ! named variables for structure elements
  USE var_lookup,only:iLookDECISIONS                           ! named variables for elements of the decision structure
@@ -115,7 +112,6 @@ contains
  real(dp),intent(in)             :: scalarVP_CanopyAir        ! canopy air vapor pressure (Pa)
  ! input: data structures
  type(var_i),intent(in)          :: type_data                 ! type of vegetation and soil
- type(var_d),intent(in)          :: attr_data                 ! spatial attributes
  type(var_d),intent(in)          :: forc_data                 ! model forcing data
  type(var_d),intent(in)          :: mpar_data                 ! model parameters
  type(model_options),intent(in)  :: model_decisions(:)        ! model decisions
@@ -134,28 +130,6 @@ contains
  real(dp)                        :: scalarStomResist          ! stomatal resistance (s m-1)
  real(dp)                        :: scalarPhotosynthesis      ! photosynthesis (umol CO2 m-2 s-1)
  real(dp)                        :: ci                        ! intercellular co2 partial pressure (Pa)
- ! ------------------------------------------------------------------------------------------------------------------------------------------------------
- ! local variables for testing
- integer(i4b),parameter          :: ixUnit=66                 ! file unit
- integer(i4b)                    :: iTrial                    ! index of model trial
- integer(i4b),parameter          :: nTrial=100                ! number of model trials
- integer(i4b)                    :: iExp                      ! index of model experiment
- integer(i4b),parameter          :: nExp=3                    ! number of model experiments
- integer(i4b),parameter          :: ixTemp=1                  ! named variable defining perturbations in leaf temperature
- integer(i4b),parameter          :: ixVPD=2                   ! named variable defining perturbations in vapor pressure deficit
- integer(i4b),parameter          :: ixPAR=3                   ! named variable defining perturbations in PAR
- real(dp)                        :: xTrial                    ! normalized trial value
- real(dp)                        :: leafTemp                  ! leaf temperature (K)
- real(dp)                        :: vpd                       ! vapor pressure deficit (Pa)
- real(dp)                        :: par                       ! absorbed PAR (W m-2)
- real(dp)                        :: SatVP_leafTemp            ! saturated vapor pressure at the leaf temperature (Pa)
- real(dp)                        :: derivNotUsed              ! derivative in saturated vapor pressure w.r.t. temperature (not used)
- real(dp)                        :: vpCanair                  ! vapor pressure of the canopy air space (Pa)
- real(dp)                        :: unitConv                  ! unit conversion factor (mol m-3, convert m s-1 --> mol H20 m-2 s-1)
- character(LEN=256)              :: filename                  ! filename
- character(LEN=4),parameter      :: cTemp='Temp'              ! named variable for temperature
- character(LEN=4),parameter      :: cVPD='VPD '               ! named variable for vapor pressure deficit
- character(LEN=4),parameter      :: cPAR='PAR '               ! named variable for PAR
  ! ------------------------------------------------------------------------------------------------------------------------------------------------------
 
  ! associate variables in the data structure
@@ -385,11 +359,10 @@ contains
  character(*),intent(out)        :: message                    ! error message
  ! ------------------------------------------------------------------------------------------------------------------------------------------------------
  ! general local variables
- character(LEN=256)              :: cmessage                   ! error message of downwind routine
  logical(lgt),parameter          :: testDerivs=.false.         ! flag to test the derivatives
  real(dp)                        :: unitConv                   ! unit conversion factor (mol m-3, convert m s-1 --> mol H20 m-2 s-1)
  real(dp)                        :: rlb                        ! leaf boundary layer rersistance (umol-1 m2 s)
- real(dp)                        :: x0,x1,x2,x3,x4             ! temporary variables
+ real(dp)                        :: x0,x1,x2                   ! temporary variables
  real(dp)                        :: co2compPt                  ! co2 compensation point (Pa)
  real(dp)                        :: fHum                       ! humidity function, fraction [0,1] 
  ! ------------------------------------------------------------------------------------------------------------------------------------------------------
@@ -1274,32 +1247,6 @@ contains
  end subroutine stomResist_NoahMP
 
 
- ! *******************************************************************************************************
- ! private subroutine quadratic: solve the equation ax2 + bx + c = 0
- ! *******************************************************************************************************
- subroutine quadratic(a, b, c, r1, r2)
- implicit none
- real(dp)  :: a, b, c  ! terms in the quadratic equation
- real(dp)  :: r1, r2   ! roots
- real(dp)  :: q
-
- if (b >= 0._dp)then
-  q = -0.5_dp * (b + sqrt(b*b - 4._dp*a*c))
- else
-  q = -0.5_dp * (b - sqrt(b*b - 4._dp*a*c))
- endif
-
- r1 = q / a
- if (q /= 0._dp)then
-  r2 = c / q
- else
-  r2 = 1.e36_dp
- endif
-
- end subroutine quadratic
-
-
- 
  ! -- end private subroutines
  ! ------------------------------------------------------------------------------------------------------------
  ! ------------------------------------------------------------------------------------------------------------

--- a/build/source/engine/systemSolv.f90
+++ b/build/source/engine/systemSolv.f90
@@ -1954,9 +1954,11 @@ contains
 
    ! - include derivatives w.r.t. ground evaporation
    if(nSnow==0 .and. iLayer==1)then  ! upper-most soil layer
-    aJac(ixSub4,ixCasNrg) = (dt/mLayerDepth(kLayer))*(-dGroundEvaporation_dTCanair/iden_water) ! dVol/dT (K-1)
-    aJac(ixSub3,ixVegNrg) = (dt/mLayerDepth(kLayer))*(-dGroundEvaporation_dTCanopy/iden_water) ! dVol/dT (K-1)
-    aJac(ixSub2,ixVegWat)   = (dt/mLayerDepth(kLayer))*(-dGroundEvaporation_dCanLiq/iden_water)  ! dVol/dLiq (kg m-2)-1
+    if(computeVegFlux)then
+     aJac(ixSub4,ixCasNrg) = (dt/mLayerDepth(kLayer))*(-dGroundEvaporation_dTCanair/iden_water) ! dVol/dT (K-1)
+     aJac(ixSub3,ixVegNrg) = (dt/mLayerDepth(kLayer))*(-dGroundEvaporation_dTCanopy/iden_water) ! dVol/dT (K-1)
+     aJac(ixSub2,ixVegWat) = (dt/mLayerDepth(kLayer))*(-dGroundEvaporation_dCanLiq/iden_water)  ! dVol/dLiq (kg m-2)-1
+    endif
     aJac(ixSub1,ixTopNrg)   = (dt/mLayerDepth(kLayer))*(-dGroundEvaporation_dTGround/iden_water) + aJac(ixSub1,ixTopNrg) ! dVol/dT (K-1)
    endif
 
@@ -2114,9 +2116,11 @@ contains
 
    ! - include derivatives w.r.t. ground evaporation
    if(nSnow==0 .and. iLayer==1)then  ! upper-most soil layer
-    aJac(jLayer,ixVegWat) = (dt/mLayerDepth(kLayer))*(-dGroundEvaporation_dCanLiq/iden_water)  ! dVol/dLiq (kg m-2)-1
-    aJac(jLayer,ixCasNrg) = (dt/mLayerDepth(kLayer))*(-dGroundEvaporation_dTCanair/iden_water) ! dVol/dT (K-1)
-    aJac(jLayer,ixVegNrg) = (dt/mLayerDepth(kLayer))*(-dGroundEvaporation_dTCanopy/iden_water) ! dVol/dT (K-1)
+    if(computeVegFlux)then
+     aJac(jLayer,ixVegWat) = (dt/mLayerDepth(kLayer))*(-dGroundEvaporation_dCanLiq/iden_water)  ! dVol/dLiq (kg m-2)-1
+     aJac(jLayer,ixCasNrg) = (dt/mLayerDepth(kLayer))*(-dGroundEvaporation_dTCanair/iden_water) ! dVol/dT (K-1)
+     aJac(jLayer,ixVegNrg) = (dt/mLayerDepth(kLayer))*(-dGroundEvaporation_dTCanopy/iden_water) ! dVol/dT (K-1)
+    endif
     aJac(jLayer,ixTopNrg) = (dt/mLayerDepth(kLayer))*(-dGroundEvaporation_dTGround/iden_water) + aJac(jLayer,ixTopNrg) ! dVol/dT (K-1)
    endif
 

--- a/build/source/engine/var_derive.f90
+++ b/build/source/engine/var_derive.f90
@@ -129,7 +129,6 @@ contains
  integer(i4b)             :: iLayer                ! loop through layers
  real(dp)                 :: fracRootLower         ! fraction of the rooting depth at the lower interface
  real(dp)                 :: fracRootUpper         ! fraction of the rooting depth at the upper interface
- real(dp)                 :: checkCalcs            ! check calculations for aquifer roots
  ! initialize error control
  err=0; message='rootDensty/'
  ! ----------------------------------------------------------------------------------

--- a/build/source/engine/vegNrgFlux.f90
+++ b/build/source/engine/vegNrgFlux.f90
@@ -587,6 +587,16 @@ contains
    dCanopyNetFlux_dGroundTemp = 0._dp   ! derivative in net canopy flux w.r.t. ground temperature (W m-2 K-1)
    dGroundNetFlux_dCanairTemp = 0._dp   ! derivative in net ground flux w.r.t. canopy air temperature (W m-2 K-1)
    dGroundNetFlux_dCanopyTemp = 0._dp   ! derivative in net ground flux w.r.t. canopy temperature (W m-2 K-1)
+   ! set liquid flux derivatives to zero (canopy evap)
+   dCanopyEvaporation_dCanLiq = 0._dp    ! derivative in canopy evaporation w.r.t. canopy liquid water content (s-1)
+   dCanopyEvaporation_dTCanair= 0._dp    ! derivative in canopy evaporation w.r.t. canopy air temperature (kg m-2 s-1 K-1)
+   dCanopyEvaporation_dTCanopy= 0._dp    ! derivative in canopy evaporation w.r.t. canopy temperature (kg m-2 s-1 K-1)
+   dCanopyEvaporation_dTGround= 0._dp    ! derivative in canopy evaporation w.r.t. ground temperature (kg m-2 s-1 K-1)
+   ! set liquid flux derivatives to zero (ground evap)
+   dGroundEvaporation_dCanLiq = 0._dp    ! derivative in ground evaporation w.r.t. canopy liquid water content (s-1)
+   dGroundEvaporation_dTCanair= 0._dp    ! derivative in ground evaporation w.r.t. canopy air temperature (kg m-2 s-1 K-1)
+   dGroundEvaporation_dTCanopy= 0._dp    ! derivative in ground evaporation w.r.t. canopy temperature (kg m-2 s-1 K-1)
+   dGroundEvaporation_dTGround= 0._dp    ! derivative in ground evaporation w.r.t. ground temperature (kg m-2 s-1 K-1)
 
    ! compute fluxes and derivatives -- separate approach for prescribed temperature and zero flux
    if(ix_bcUpprTdyn == prescribedTemp)then

--- a/build/source/engine/vegNrgFlux.f90
+++ b/build/source/engine/vegNrgFlux.f90
@@ -150,11 +150,17 @@ contains
                        dGroundNetFlux_dCanopyTemp,              & ! intent(out): derivative in net ground flux w.r.t. canopy temperature (W m-2 K-1)
                        dGroundNetFlux_dGroundTemp,              & ! intent(out): derivative in net ground flux w.r.t. ground temperature (W m-2 K-1)
 
-                       ! output liquid water flux derivarives
+                       ! output liquid water flux derivarives (canopy evap)
                        dCanopyEvaporation_dCanLiq,              & ! intent(out): derivative in canopy evaporation w.r.t. canopy liquid water content (s-1)
                        dCanopyEvaporation_dTCanair,             & ! intent(out): derivative in canopy evaporation w.r.t. canopy air temperature (kg m-2 s-1 K-1)
                        dCanopyEvaporation_dTCanopy,             & ! intent(out): derivative in canopy evaporation w.r.t. canopy temperature (kg m-2 s-1 K-1)
                        dCanopyEvaporation_dTGround,             & ! intent(out): derivative in canopy evaporation w.r.t. ground temperature (kg m-2 s-1 K-1)
+
+                       ! output: liquid water flux derivarives (ground evap)
+                       dGroundEvaporation_dCanLiq,              & ! intent(out): derivative in ground evaporation w.r.t. canopy liquid water content (s-1)
+                       dGroundEvaporation_dTCanair,             & ! intent(out): derivative in ground evaporation w.r.t. canopy air temperature (kg m-2 s-1 K-1)
+                       dGroundEvaporation_dTCanopy,             & ! intent(out): derivative in ground evaporation w.r.t. canopy temperature (kg m-2 s-1 K-1)
+                       dGroundEvaporation_dTGround,             & ! intent(out): derivative in ground evaporation w.r.t. ground temperature (kg m-2 s-1 K-1)
 
                        ! output: cross derivative terms
                        dCanopyNetFlux_dCanLiq,                  & ! intent(out): derivative in net canopy fluxes w.r.t. canopy liquid water content (J kg-1 s-1)
@@ -222,11 +228,16 @@ contains
  real(dp),intent(out)            :: dGroundNetFlux_dCanairTemp      ! derivative in net ground flux w.r.t. canopy air temperature (W m-2 K-1)
  real(dp),intent(out)            :: dGroundNetFlux_dCanopyTemp      ! derivative in net ground flux w.r.t. canopy temperature (W m-2 K-1)
  real(dp),intent(out)            :: dGroundNetFlux_dGroundTemp      ! derivative in net ground flux w.r.t. ground temperature (W m-2 K-1)
- ! output: liquid flux derivatives
+ ! output: liquid flux derivatives (canopy evap)
  real(dp),intent(out)            :: dCanopyEvaporation_dCanLiq      ! derivative in canopy evaporation w.r.t. canopy liquid water content (s-1)
  real(dp),intent(out)            :: dCanopyEvaporation_dTCanair     ! derivative in canopy evaporation w.r.t. canopy air temperature (kg m-2 s-1 K-1)
  real(dp),intent(out)            :: dCanopyEvaporation_dTCanopy     ! derivative in canopy evaporation w.r.t. canopy temperature (kg m-2 s-1 K-1)
  real(dp),intent(out)            :: dCanopyEvaporation_dTGround     ! derivative in canopy evaporation w.r.t. ground temperature (kg m-2 s-1 K-1)
+ ! output: liquid flux derivatives (ground evap)
+ real(dp),intent(out)            :: dGroundEvaporation_dCanLiq      ! derivative in ground evaporation w.r.t. canopy liquid water content (s-1)
+ real(dp),intent(out)            :: dGroundEvaporation_dTCanair     ! derivative in ground evaporation w.r.t. canopy air temperature (kg m-2 s-1 K-1)
+ real(dp),intent(out)            :: dGroundEvaporation_dTCanopy     ! derivative in ground evaporation w.r.t. canopy temperature (kg m-2 s-1 K-1)
+ real(dp),intent(out)            :: dGroundEvaporation_dTGround     ! derivative in ground evaporation w.r.t. ground temperature (kg m-2 s-1 K-1)
  ! output: cross derivative terms
  real(dp),intent(out)            :: dCanopyNetFlux_dCanLiq          ! derivative in net canopy fluxes w.r.t. canopy liquid water content (J kg-1 s-1)
  real(dp),intent(out)            :: dGroundNetFlux_dCanLiq          ! derivative in net ground fluxes w.r.t. canopy liquid water content (J kg-1 s-1)
@@ -356,11 +367,16 @@ contains
  real(dp)                       :: dTurbFluxGround_dTCanopy         ! derivative in net ground turbulent fluxes w.r.t. canopy temperature (W m-2 K-1)
  real(dp)                       :: dTurbFluxGround_dTGround         ! derivative in net ground turbulent fluxes w.r.t. ground temperature (W m-2 K-1)
  real(dp)                       :: dTurbFluxGround_dCanLiq          ! derivative in net ground turbulent fluxes w.r.t. canopy liquid water content (J kg-1 s-1)
- ! (liquid water flux derivatives)
+ ! (liquid water flux derivatives -- canopy evap)
  real(dp)                       :: dLatHeatCanopyEvap_dCanLiq       ! derivative in latent heat of canopy evaporation w.r.t. canopy liquid water content (W kg-1)
  real(dp)                       :: dLatHeatCanopyEvap_dTCanair      ! derivative in latent heat of canopy evaporation w.r.t. canopy air temperature (W m-2 K-1)
  real(dp)                       :: dLatHeatCanopyEvap_dTCanopy      ! derivative in latent heat of canopy evaporation w.r.t. canopy temperature (W m-2 K-1)
  real(dp)                       :: dLatHeatCanopyEvap_dTGround      ! derivative in latent heat of canopy evaporation w.r.t. ground temperature (W m-2 K-1)
+ ! (liquid water flux derivatives -- ground evap)
+ real(dp)                       :: dLatHeatGroundEvap_dCanLiq       ! derivative in latent heat of ground evaporation w.r.t. canopy liquid water content (J kg-1 s-1)
+ real(dp)                       :: dLatHeatGroundEvap_dTCanair      ! derivative in latent heat of ground evaporation w.r.t. canopy air temperature (W m-2 K-1)
+ real(dp)                       :: dLatHeatGroundEvap_dTCanopy      ! derivative in latent heat of ground evaporation w.r.t. canopy temperature (W m-2 K-1)
+ real(dp)                       :: dLatHeatGroundEvap_dTGround      ! derivative in latent heat of ground evaporation w.r.t. ground temperature (W m-2 K-1)
  ! ---------------------------------------------------------------------------------------
  ! point to variables in the data structure
  ! ---------------------------------------------------------------------------------------
@@ -1170,11 +1186,16 @@ contains
                     dTurbFluxGround_dTCanair,             & ! intent(out): derivative in net ground turbulent fluxes w.r.t. canopy air temperature (W m-2 K-1)
                     dTurbFluxGround_dTCanopy,             & ! intent(out): derivative in net ground turbulent fluxes w.r.t. canopy temperature (W m-2 K-1)
                     dTurbFluxGround_dTGround,             & ! intent(out): derivative in net ground turbulent fluxes w.r.t. ground temperature (W m-2 K-1)
-                    ! output: liquid flux derivatives
+                    ! output: liquid flux derivatives (canopy evap)
                     dLatHeatCanopyEvap_dCanLiq,           & ! intent(out): derivative in latent heat of canopy evaporation w.r.t. canopy liquid water content (W kg-1)
                     dLatHeatCanopyEvap_dTCanair,          & ! intent(out): derivative in latent heat of canopy evaporation w.r.t. canopy air temperature (W m-2 K-1)
                     dLatHeatCanopyEvap_dTCanopy,          & ! intent(out): derivative in latent heat of canopy evaporation w.r.t. canopy temperature (W m-2 K-1)
                     dLatHeatCanopyEvap_dTGround,          & ! intent(out): derivative in latent heat of canopy evaporation w.r.t. ground temperature (W m-2 K-1)
+                    ! output: liquid flux derivatives (ground evap)
+                    dLatHeatGroundEvap_dCanLiq,           & ! intent(out): derivative in latent heat of ground evaporation w.r.t. canopy liquid water content (J kg-1 s-1)
+                    dLatHeatGroundEvap_dTCanair,          & ! intent(out): derivative in latent heat of ground evaporation w.r.t. canopy air temperature
+                    dLatHeatGroundEvap_dTCanopy,          & ! intent(out): derivative in latent heat of ground evaporation w.r.t. canopy temperature
+                    dLatHeatGroundEvap_dTGround,          & ! intent(out): derivative in latent heat of ground evaporation w.r.t. ground temperature
                     ! output: cross derivatives
                     dTurbFluxCanair_dCanLiq,              & ! intent(out): derivative in net canopy air space fluxes w.r.t. canopy liquid water content (J kg-1 s-1)
                     dTurbFluxCanopy_dCanLiq,              & ! intent(out): derivative in net canopy turbulent fluxes w.r.t. canopy liquid water content (J kg-1 s-1)
@@ -1382,6 +1403,12 @@ contains
     dCanopyEvaporation_dTCanopy = 0._dp  ! (kg m-2 s-1 K-1)
     dCanopyEvaporation_dTGround = 0._dp  ! (kg m-2 s-1 K-1)
    endif
+
+   ! compute the liquid water derivarives (ground evap)
+   dGroundEvaporation_dCanLiq  = dLatHeatGroundEvap_dCanLiq/LH_vap    ! (s-1)
+   dGroundEvaporation_dTCanair = dLatHeatGroundEvap_dTCanair/LH_vap   ! (kg m-2 s-1 K-1)
+   dGroundEvaporation_dTCanopy = dLatHeatGroundEvap_dTCanopy/LH_vap   ! (kg m-2 s-1 K-1)
+   dGroundEvaporation_dTGround = dLatHeatGroundEvap_dTGround/LH_vap   ! (kg m-2 s-1 K-1)
 
    ! compute the cross derivative terms (only related to turbulent fluxes; specifically canopy evaporation and transpiration)
    dCanopyNetFlux_dCanLiq = dTurbFluxCanopy_dCanLiq  ! derivative in net canopy fluxes w.r.t. canopy liquid water content (J kg-1 s-1)
@@ -2508,11 +2535,16 @@ contains
                        dTurbFluxGround_dTCanair,      & ! intent(out): derivative in net ground turbulent fluxes w.r.t. canopy air temperature (W m-2 K-1)
                        dTurbFluxGround_dTCanopy,      & ! intent(out): derivative in net ground turbulent fluxes w.r.t. canopy temperature (W m-2 K-1)
                        dTurbFluxGround_dTGround,      & ! intent(out): derivative in net ground turbulent fluxes w.r.t. ground temperature (W m-2 K-1)
-                       ! output: liquid flux derivatives
+                       ! output: liquid flux derivatives (canopy evap)
                        dLatHeatCanopyEvap_dCanLiq,    & ! intent(out): derivative in latent heat of canopy evaporation w.r.t. canopy liquid water content (J kg-1 s-1)
                        dLatHeatCanopyEvap_dTCanair,   & ! intent(out): derivative in latent heat of canopy evaporation w.r.t. canopy air temperature (W m-2 K-1)
                        dLatHeatCanopyEvap_dTCanopy,   & ! intent(out): derivative in latent heat of canopy evaporation w.r.t. canopy temperature (W m-2 K-1)
                        dLatHeatCanopyEvap_dTGround,   & ! intent(out): derivative in latent heat of canopy evaporation w.r.t. ground temperature (W m-2 K-1)
+                       ! output: liquid flux derivatives (ground evap)
+                       dLatHeatGroundEvap_dCanLiq,    & ! intent(out): derivative in latent heat of ground evaporation w.r.t. canopy liquid water content (J kg-1 s-1)
+                       dLatHeatGroundEvap_dTCanair,   & ! intent(out): derivative in latent heat of ground evaporation w.r.t. canopy air temperature
+                       dLatHeatGroundEvap_dTCanopy,   & ! intent(out): derivative in latent heat of ground evaporation w.r.t. canopy temperature
+                       dLatHeatGroundEvap_dTGround,   & ! intent(out): derivative in latent heat of ground evaporation w.r.t. ground temperature
                        ! output: cross derivatives
                        dTurbFluxCanair_dCanLiq,       & ! intent(out): derivative in net canopy air space fluxes w.r.t. canopy liquid water content (J kg-1 s-1)
                        dTurbFluxCanopy_dCanLiq,       & ! intent(out): derivative in net canopy turbulent fluxes w.r.t. canopy liquid water content (J kg-1 s-1)
@@ -2595,11 +2627,16 @@ contains
  real(dp),intent(out)          :: dTurbFluxGround_dTCanair     ! derivative in net ground turbulent fluxes w.r.t. canopy air temperature (W m-2 K-1)
  real(dp),intent(out)          :: dTurbFluxGround_dTCanopy     ! derivative in net ground turbulent fluxes w.r.t. canopy temperature (W m-2 K-1)
  real(dp),intent(out)          :: dTurbFluxGround_dTGround     ! derivative in net ground turbulent fluxes w.r.t. ground temperature (W m-2 K-1)
- ! output: liquid flux derivatives
+ ! output: liquid flux derivatives (canopy evap)
  real(dp),intent(out)          :: dLatHeatCanopyEvap_dCanLiq   ! derivative in latent heat of canopy evaporation w.r.t. canopy liquid water content (W kg-1)
  real(dp),intent(out)          :: dLatHeatCanopyEvap_dTCanair  ! derivative in latent heat of canopy evaporation w.r.t. canopy air temperature (W m-2 K-1)
  real(dp),intent(out)          :: dLatHeatCanopyEvap_dTCanopy  ! derivative in latent heat of canopy evaporation w.r.t. canopy temperature (W m-2 K-1)
  real(dp),intent(out)          :: dLatHeatCanopyEvap_dTGround  ! derivative in latent heat of canopy evaporation w.r.t. ground temperature (W m-2 K-1)
+ ! output: liquid flux derivatives (ground evap)
+ real(dp),intent(out)          :: dLatHeatGroundEvap_dCanLiq   ! derivative in latent heat of ground evaporation w.r.t. canopy liquid water content (J kg-1 s-1)
+ real(dp),intent(out)          :: dLatHeatGroundEvap_dTCanair  ! derivative in latent heat of ground evaporation w.r.t. canopy air temperature (W m-2 K-1)
+ real(dp),intent(out)          :: dLatHeatGroundEvap_dTCanopy  ! derivative in latent heat of ground evaporation w.r.t. canopy temperature (W m-2 K-1)
+ real(dp),intent(out)          :: dLatHeatGroundEvap_dTGround  ! derivative in latent heat of ground evaporation w.r.t. ground temperature (W m-2 K-1)
  ! output: cross derivatives
  real(dp),intent(out)          :: dTurbFluxCanair_dCanLiq      ! derivative in net canopy air space fluxes w.r.t. canopy liquid water content (J kg-1 s-1)
  real(dp),intent(out)          :: dTurbFluxCanopy_dCanLiq      ! derivative in net canopy turbulent fluxes w.r.t. canopy liquid water content (J kg-1 s-1)
@@ -2649,9 +2686,6 @@ contains
  real(dp)                      :: dLatHeatCanopyTrans_dTCanair ! derivative in the canopy transpiration flux w.r.t. canopy air temperature
  real(dp)                      :: dLatHeatCanopyTrans_dTCanopy ! derivative in the canopy transpiration flux w.r.t. canopy temperature
  real(dp)                      :: dLatHeatCanopyTrans_dTGround ! derivative in the canopy transpiration flux w.r.t. ground temperature
- real(dp)                      :: dLatHeatGround_dTCanair      ! derivative in the ground latent heat flux w.r.t. canopy air temperature
- real(dp)                      :: dLatHeatGround_dTCanopy      ! derivative in the ground latent heat flux w.r.t. canopy temperature
- real(dp)                      :: dLatHeatGround_dTGround      ! derivative in the ground latent heat flux w.r.t. ground temperature
  ! local variables -- wetted fraction derivatives
  real(dp)                      :: dLatHeatCanopyEvap_dWetFrac  ! derivative in the latent heat of canopy evaporation w.r.t. canopy wet fraction (W m-2)
  real(dp)                      :: dLatHeatCanopyTrans_dWetFrac ! derivative in the latent heat of canopy transpiration w.r.t. canopy wet fraction (W m-2)
@@ -2865,11 +2899,11 @@ contains
    ! latent heat flux from the ground
    fPart1 = -latHeatSubVapGround*latentHeatConstant*groundConductanceLH       ! function of the first part
    fPart2 = (satVP_GroundTemp*soilRelHumidity - VP_CanopyAir)                 ! function of the second part
-   dLatHeatGround_dTCanair      = -latHeatSubVapGround*latentHeatConstant*dGroundCondLH_dCanairTemp*fPart2 - dVPCanopyAir_dTCanair*fPart1
-   dLatHeatGround_dTCanopy      = -latHeatSubVapGround*latentHeatConstant*dGroundCondLH_dCanopyTemp*fPart2 - dVPCanopyAir_dTCanopy*fPart1
-   dLatHeatGround_dTGround      = -latHeatSubVapGround*latentHeatConstant*dGroundCondLH_dGroundTemp*fPart2 + (dSVPGround_dGroundTemp*soilRelHumidity - dVPCanopyAir_dTGround)*fPart1
-   !write(*,'(a,3(f20.8,1x))') 'dLatHeatGround_dTCanair, dLatHeatGround_dTCanopy, dLatHeatGround_dTGround                = ', &
-   !                            dLatHeatGround_dTCanair, dLatHeatGround_dTCanopy, dLatHeatGround_dTGround
+   dLatHeatGroundEvap_dTCanair = -latHeatSubVapGround*latentHeatConstant*dGroundCondLH_dCanairTemp*fPart2 - dVPCanopyAir_dTCanair*fPart1
+   dLatHeatGroundEvap_dTCanopy = -latHeatSubVapGround*latentHeatConstant*dGroundCondLH_dCanopyTemp*fPart2 - dVPCanopyAir_dTCanopy*fPart1
+   dLatHeatGroundEvap_dTGround = -latHeatSubVapGround*latentHeatConstant*dGroundCondLH_dGroundTemp*fPart2 + (dSVPGround_dGroundTemp*soilRelHumidity - dVPCanopyAir_dTGround)*fPart1
+   !write(*,'(a,3(f20.8,1x))') 'dLatHeatGroundEvap_dTCanair, dLatHeatGroundEvap_dTCanopy, dLatHeatGroundEvap_dTGround                = ', &
+   !                            dLatHeatGroundEvap_dTCanair, dLatHeatGroundEvap_dTCanopy, dLatHeatGroundEvap_dTGround
 
    ! latent heat associated with canopy evaporation w.r.t. wetted fraction of the canopy
    dPart1 = -latHeatSubVapCanopy*latentHeatConstant*leafConductance
@@ -2909,16 +2943,16 @@ contains
    dVPCanopyAir_dCanLiq         = 0._dp
 
    ! set derivatives for ground fluxes w.r.t canopy temperature to zero (no canopy, so fluxes are undefined)
-   dSenHeatGround_dTCanair = 0._dp
-   dSenHeatGround_dTCanopy = 0._dp
-   dLatHeatGround_dTCanair = 0._dp
-   dLatHeatGround_dTCanopy = 0._dp
+   dSenHeatGround_dTCanair     = 0._dp
+   dSenHeatGround_dTCanopy     = 0._dp
+   dLatHeatGroundEvap_dTCanair = 0._dp
+   dLatHeatGroundEvap_dTCanopy = 0._dp
 
    ! compute derivatives for the ground fluxes w.r.t. ground temperature
-   dSenHeatGround_dTGround = (-volHeatCapacityAir*dGroundCondSH_dGroundTemp)*(groundTemp - airtemp) + &                                               ! d(ground sensible heat flux)/d(ground temp)
-                             (-volHeatCapacityAir*groundConductanceSH)
-   dLatHeatGround_dTGround = (-latHeatSubVapGround*latentHeatConstant*dGroundCondLH_dGroundTemp)*(satVP_GroundTemp*soilRelHumidity - VPair) + &       ! d(ground latent heat flux)/d(ground temp)
-                             (-latHeatSubVapGround*latentHeatConstant*groundConductanceLH)*dSVPGround_dGroundTemp*soilRelHumidity
+   dSenHeatGround_dTGround     = (-volHeatCapacityAir*dGroundCondSH_dGroundTemp)*(groundTemp - airtemp) + &                                               ! d(ground sensible heat flux)/d(ground temp)
+                                 (-volHeatCapacityAir*groundConductanceSH)
+   dLatHeatGroundEvap_dTGround = (-latHeatSubVapGround*latentHeatConstant*dGroundCondLH_dGroundTemp)*(satVP_GroundTemp*soilRelHumidity - VPair) + &       ! d(ground latent heat flux)/d(ground temp)
+                                 (-latHeatSubVapGround*latentHeatConstant*groundConductanceLH)*dSVPGround_dGroundTemp*soilRelHumidity
 
    !print*, 'dGroundCondLH_dGroundTemp = ', dGroundCondLH_dGroundTemp
 
@@ -2946,15 +2980,16 @@ contains
   dTurbFluxCanopy_dTCanair = dSenHeatCanopy_dTCanair + dLatHeatCanopyEvap_dTCanair + dLatHeatCanopyTrans_dTCanair  ! derivative in net canopy turbulent fluxes w.r.t. canopy air temperature (W m-2 K-1)
   dTurbFluxCanopy_dTCanopy = dSenHeatCanopy_dTCanopy + dLatHeatCanopyEvap_dTCanopy + dLatHeatCanopyTrans_dTCanopy  ! derivative in net canopy turbulent fluxes w.r.t. canopy temperature (W m-2 K-1)
   dTurbFluxCanopy_dTGround = dSenHeatCanopy_dTGround + dLatHeatCanopyEvap_dTGround + dLatHeatCanopyTrans_dTGround  ! derivative in net canopy turbulent fluxes w.r.t. ground temperature (W m-2 K-1)
-  dTurbFluxGround_dTCanair = dSenHeatGround_dTCanair + dLatHeatGround_dTCanair                                     ! derivative in net ground turbulent fluxes w.r.t. canopy air temperature (W m-2 K-1)
-  dTurbFluxGround_dTCanopy = dSenHeatGround_dTCanopy + dLatHeatGround_dTCanopy                                     ! derivative in net ground turbulent fluxes w.r.t. canopy temperature (W m-2 K-1)
-  dTurbFluxGround_dTGround = dSenHeatGround_dTGround + dLatHeatGround_dTGround                                     ! derivative in net ground turbulent fluxes w.r.t. ground temperature (W m-2 K-1)
+  dTurbFluxGround_dTCanair = dSenHeatGround_dTCanair + dLatHeatGroundEvap_dTCanair                                 ! derivative in net ground turbulent fluxes w.r.t. canopy air temperature (W m-2 K-1)
+  dTurbFluxGround_dTCanopy = dSenHeatGround_dTCanopy + dLatHeatGroundEvap_dTCanopy                                 ! derivative in net ground turbulent fluxes w.r.t. canopy temperature (W m-2 K-1)
+  dTurbFluxGround_dTGround = dSenHeatGround_dTGround + dLatHeatGroundEvap_dTGround                                 ! derivative in net ground turbulent fluxes w.r.t. ground temperature (W m-2 K-1)
   ! (liquid water derivatives)
   dLatHeatCanopyEvap_dCanLiq = dLatHeatCanopyEvap_dWetFrac*dCanopyWetFraction_dWat                                 ! derivative in latent heat of canopy evaporation w.r.t. canopy liquid water (W kg-1)
+  dLatHeatGroundEvap_dCanLiq = latHeatSubVapGround*latentHeatConstant*groundConductanceLH*dVPCanopyAir_dCanLiq     ! derivative in latent heat of ground evaporation w.r.t. canopy liquid water (J kg-1 s-1)
   ! (cross deriavtives)
   dTurbFluxCanair_dCanLiq  = 0._dp                                                                                 ! derivative in net canopy air space fluxes w.r.t. canopy liquid water content (J kg-1 s-1)
   dTurbFluxCanopy_dCanLiq  = dLatHeatCanopyEvap_dCanLiq + dLatHeatCanopyTrans_dCanLiq                              ! derivative in net canopy turbulent fluxes w.r.t. canopy liquid water content (J kg-1 s-1)
-  dTurbFluxGround_dCanLiq  = latHeatSubVapGround*latentHeatConstant*groundConductanceLH*dVPCanopyAir_dCanLiq       ! derivative in net ground turbulent fluxes w.r.t. canopy liquid water content (J kg-1 s-1)
+  dTurbFluxGround_dCanLiq  = dLatHeatGroundEvap_dCanLiq                                                            ! derivative in net ground turbulent fluxes w.r.t. canopy liquid water content (J kg-1 s-1)
  else ! (just make sure we return something)
   ! (energy derivatives)
   dTurbFluxCanair_dTCanair = 0._dp
@@ -2968,6 +3003,7 @@ contains
   dTurbFluxGround_dTGround = 0._dp
   ! (liquid water derivatives)
   dLatHeatCanopyEvap_dCanLiq   = 0._dp
+  dLatHeatGroundEvap_dCanLiq   = 0._dp
   ! (cross deriavtives)
   dTurbFluxCanair_dCanLiq  = 0._dp
   dTurbFluxCanopy_dCanLiq  = 0._dp

--- a/build/source/engine/vegNrgFlux.f90
+++ b/build/source/engine/vegNrgFlux.f90
@@ -844,7 +844,6 @@ contains
                     scalarVP_CanopyAir,                & ! intent(in): canopy air vapor pressure (Pa)
                     ! input: data structures
                     type_data,                         & ! intent(in):    type of vegetation and soil
-                    attr_data,                         & ! intent(in):    spatial attributes
                     forc_data,                         & ! intent(in):    model forcing data
                     mpar_data,                         & ! intent(in):    model parameters
                     model_decisions,                   & ! intent(in):    model decisions

--- a/build/source/engine/vegSWavRad.f90
+++ b/build/source/engine/vegSWavRad.f90
@@ -71,7 +71,7 @@ contains
  USE data_struc,only:model_decisions                              ! model decision structure
  USE var_lookup,only:iLookDECISIONS                               ! named variables for elements of the decision structure
  ! model variables, parameters, etc.
- USE data_struc,only:type_data,mvar_data,indx_data     ! data structures
+ USE data_struc,only:type_data,mvar_data               ! data structures
  USE var_lookup,only:iLookTIME,iLookTYPE,iLookATTR,iLookFORCE,iLookPARAM,iLookMVAR,iLookBVAR,iLookINDEX  ! named variables for structure elements
  implicit none
  ! dummy variables


### PR DESCRIPTION
Include derivatives of ground evap w.r.t. relevant state variables in an attempt to speed-up convergence. This code has been run for all test cases and results are very similar (though, as expected, results are not within machine precision because the numerical solution has changed).

NOTE: This branch should be merged AFTER feature/cleanUp