### PR TITLE
Adding ONLY the files for git-lfs for GRU commit.

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+*tgz filter=lfs diff=lfs merge=lfs -text

--- a/settings_gru_dimension.tgz
+++ b/settings_gru_dimension.tgz
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:38e987ce8af2948b1dbd83977fd617c02be16816dc1814ef4b1399fba78bfb40
+size 185014


### PR DESCRIPTION
This is a pull request to test git-lfs for SUMMA.  I've added only one file supported by git-lfs.  I'd like to then fetch upstream and merge to my local SUMMA and see if I can push back to my fork.  If I can't I think we're still going to have problems with git-lfs.