### PR TITLE
Incorrect function evaluation in lineSearch

### DIFF
--- a/build/source/engine/systemSolv.f90
+++ b/build/source/engine/systemSolv.f90
@@ -666,9 +666,6 @@ contains
  if(err/=0)then; message=trim(message)//trim(cmessage); return; endif  ! (check for errors)
 
  ! compute the function evaluation
- !fOld=0.5_dp*norm2(real(rVec, dp)/fScale)  ! NOTE: norm2 = sqrt(sum((rVec/fScale)**2._dp))
-
-
  rVecScaled = real(rVec, dp)/fScale
  fOld=0.5_dp*dot_product(rVecScaled,rVecScaled) 
 
@@ -2775,8 +2772,6 @@ contains
    if(err/=0)then; message=trim(message)//trim(cmessage); return; endif  ! (check for errors)
 
    ! compute the function evaluation
-   !f=0.5_dp*norm2(real(rVec, dp)/fScale)  ! NOTE: norm2 = sqrt(sum((rVec/fScale)**2._dp))
-
    rVecScaled = real(rVec, dp)/fScale
    f=0.5_dp*dot_product(rVecScaled,rVecScaled) 
 

--- a/build/source/engine/systemSolv.f90
+++ b/build/source/engine/systemSolv.f90
@@ -315,6 +315,7 @@ contains
  real(qp),dimension(nState)      :: sMul    ! NOTE: qp           ! multiplier for state vector for the residual calculations
  real(qp),dimension(nState)      :: rAdd    ! NOTE: qp           ! additional terms in the residual vector
  real(qp),dimension(nState)      :: rVec    ! NOTE: qp           ! residual vector
+ real(dp),dimension(nState)      :: rVecScaled                   ! scaled residual vector
  real(dp),dimension(nState)      :: xInc                         ! iteration increment
  real(dp),dimension(nState)      :: grad                         ! gradient of the function vector = matmul(rVec,aJac)
  real(dp),dimension(nState,nRHS) :: rhs                          ! the nState-by-nRHS matrix of matrix B, for the linear system A.X=B
@@ -665,7 +666,11 @@ contains
  if(err/=0)then; message=trim(message)//trim(cmessage); return; endif  ! (check for errors)
 
  ! compute the function evaluation
- fOld=0.5_dp*norm2(real(rVec, dp)/fScale)  ! NOTE: norm2 = sqrt(sum((rVec/fScale)**2._dp))
+ !fOld=0.5_dp*norm2(real(rVec, dp)/fScale)  ! NOTE: norm2 = sqrt(sum((rVec/fScale)**2._dp))
+
+
+ rVecScaled = real(rVec, dp)/fScale
+ fOld=0.5_dp*dot_product(rVecScaled,rVecScaled) 
 
  ! ==========================================================================================================================================
  ! ==========================================================================================================================================
@@ -2770,7 +2775,10 @@ contains
    if(err/=0)then; message=trim(message)//trim(cmessage); return; endif  ! (check for errors)
 
    ! compute the function evaluation
-   f=0.5_dp*norm2(real(rVec, dp)/fScale)  ! NOTE: norm2 = sqrt(sum((rVec/fScale)**2._dp))
+   !f=0.5_dp*norm2(real(rVec, dp)/fScale)  ! NOTE: norm2 = sqrt(sum((rVec/fScale)**2._dp))
+
+   rVecScaled = real(rVec, dp)/fScale
+   f=0.5_dp*dot_product(rVecScaled,rVecScaled) 
 
    ! check
    if(printFlag)then


### PR DESCRIPTION
The previous code computed the function norm2(rVec,rVec)/2, which was actually inconsistent with the gradient calculations used in lineSearch. The correct function is dot_product(rVec,rVec)/2, and the code has been updated.

The code has been checked with all test cases, with correlations between the bugFix/wrongFunction branch and the bugFix/develop branch >0.99. We do not match numerical precision because the numerical solution has changed.

Spot checks indicate a 10% speed-up.
