### PR TITLE
Bug fix to compile correctly on hydro-c1 with ifort compiler

### DIFF
--- a/build/source/dshare/outpt_stat.f90
+++ b/build/source/dshare/outpt_stat.f90
@@ -152,11 +152,11 @@ contains
   ! only treat stats of scalars - all others handled separately
   if (meta(iVar)%varType==iLookVarType%scalarv) then
 
-   selecttype (dat)
-    typeis (real(dp)); tdata = dat(iVar)
-    typeis (dlength) ; tdata = dat(iVar)%dat(1)
-    typeis (ilength) ; tdata = real(dat(iVar)%dat(1))
-    class default;err=20;message=trim(message)//'dat type not found';return
+   select type (dat)
+    type is (real(dp)); tdata = dat(iVar)
+    type is (dlength) ; tdata = dat(iVar)%dat(1)
+    type is (ilength) ; tdata = real(dat(iVar)%dat(1))
+    class default; err=20; message=trim(message)//'dat type not found';return
    endselect
 
    ! claculate statistics
@@ -207,9 +207,9 @@ contains
  iFreq = meta%outFreq
 
  ! pack back into struc
- selecttype (stat)
-  typeis (ilength); tstat = real(stat%dat)
-  typeis (dlength); tstat = stat%dat
+ select type (stat)
+  type is (ilength); tstat = real(stat%dat)
+  type is (dlength); tstat = stat%dat
   class default;err=20;message=trim(message)//'stat type not found';return
  endselect
 
@@ -281,9 +281,9 @@ contains
  endif
 
  ! pack back into struc
- selecttype (stat)
-  typeis (ilength); stat%dat = int(tstat)
-  typeis (dlength); stat%dat = tstat
+ select type (stat)
+  type is (ilength); stat%dat = int(tstat)
+  type is (dlength); stat%dat = tstat
   class default;err=20;message=trim(message)//'stat type not found';return
  endselect
 

--- a/build/source/netcdf/modelwrite.f90
+++ b/build/source/netcdf/modelwrite.f90
@@ -66,16 +66,16 @@ contains
 
   ! write data
   if (iHRU.ne.integerMissing) then
-   selecttype (dat)
-    typeis (integer)
+   select type (dat)
+    type is (integer)
      err = nf90_put_var(ncid(modelTime),meta(iVar)%ncVarID(iLookStat%inst),(/dat(iVar)/),start=(/iHRU/),count=(/1/))
-    typeis (real(dp))
+    type is (real(dp))
      err = nf90_put_var(ncid(modelTime),meta(iVar)%ncVarID(iLookStat%inst),(/dat(iVar)/),start=(/iHRU/),count=(/1/))
     class default; err=20; message=trim(message)//'unkonwn dat type (with HRU)'; return
    endselect
   else
-   selecttype (dat)
-    typeis (real(dp))
+   select type (dat)
+    type is (real(dp))
      err = nf90_put_var(ncid(modelTime),meta(iVar)%ncVarID(iLookStat%inst),(/dat(iVar)/),start=(/1/),count=(/1/))
     class default; err=20; message=trim(message)//'unkonwn dat type (no HRU)'; return
    endselect
@@ -151,8 +151,8 @@ contains
 
     ! handle time first
     if (meta(iVar)%varName=='time') then    
-     selecttype(stat)
-      typeis (dlength)
+     select type(stat)
+      type is (dlength)
        err = nf90_inq_varid(ncid(iFreq),trim(meta(iVar)%varName),ncVarID) 
        call netcdf_err(err,message); if (err/=0) return
        err = nf90_put_var(ncid(iFreq),ncVarID,(/stat(iVar)%dat(iLookStat%inst)/),start=(/outputTimestep(iFreq)/),count=(/1,1/))
@@ -172,16 +172,16 @@ contains
 
      ! stats/dats output - select data type
      if (meta(iVar)%varType==iLookVarType%scalarv) then
-       selecttype(stat)
-        typeis (ilength)
+       select type(stat)
+        type is (ilength)
          err = nf90_put_var(ncid(iFreq),meta(iVar)%ncVarID(iStat),(/stat(iVar)%dat(iStat)/),start=(/iHRU,outputTimestep(iFreq)/),count=(/1,1/))
-        typeis (dlength)
+        type is (dlength)
          err = nf90_put_var(ncid(iFreq),meta(iVar)%ncVarID(iStat),(/stat(iVar)%dat(iStat)/),start=(/iHRU,outputTimestep(iFreq)/),count=(/1,1/))
         class default; err=20; message=trim(message)//'stats must be scalarv and either ilength of dlength'; return
        endselect  ! stat 
      else
-      selecttype (dat)
-       typeis (dlength)
+      select type (dat)
+       type is (dlength)
         selectcase (meta(iVar)%varType)
          case(iLookVarType%wLength); err = nf90_put_var(ncid(iFreq),meta(iVar)%ncVarID(iStat),(/dat(iVar)%dat/),start=(/iHRU,1,outputTimestep(iFreq)/),count=(/1,maxSpectral,1/))
          case(iLookVarType%midToto); err = nf90_put_var(ncid(iFreq),meta(iVar)%ncVarID(iStat),(/dat(iVar)%dat/),start=(/iHRU,midTotoStartIndex/),count=(/1,nLayers/))
@@ -191,7 +191,7 @@ contains
          case(iLookVarType%ifcSnow); err = nf90_put_var(ncid(iFreq),meta(iVar)%ncVarID(iStat),(/dat(iVar)%dat/),start=(/iHRU,ifcSnowStartIndex/),count=(/1,nSnow/))
          case(iLookVarType%ifcSoil); err = nf90_put_var(ncid(iFreq),meta(iVar)%ncVarID(iStat),(/dat(iVar)%dat/),start=(/iHRU,ifcSoilStartIndex/),count=(/1,nSoil/))
         endselect ! vartype
-       typeis (ilength)
+       type is (ilength)
         selectcase (meta(iVar)%varType)
          case(iLookVarType%wLength); err = nf90_put_var(ncid(iFreq),meta(iVar)%ncVarID(iStat),(/dat(iVar)%dat/),start=(/iHRU,1,outputTimestep(iFreq)/),count=(/1,maxSpectral,1/))
          case(iLookVarType%midToto); err = nf90_put_var(ncid(iFreq),meta(iVar)%ncVarID(iStat),(/dat(iVar)%dat/),start=(/iHRU,midTotoStartIndex/),count=(/1,nLayers/))


### PR DESCRIPTION
The 'select type' construct appeared as 'selecttype' (without space)
The 'type is' statement appeared as 'typeis' (without spaces)