### PR TITLE
Feature/merge allocate

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,7 +22,7 @@ summa.exe
 .DS_Store
 *_local
 *log
-# makefile
-*-local
-make.out
 summa.exe.dSYM*
+# makefile
+make.out
+Makefile-*

--- a/build/source/driver/multi_driver.f90
+++ b/build/source/driver/multi_driver.f90
@@ -140,7 +140,7 @@ USE mDecisions_module,only:&                                ! look-up values for
 USE mDecisions_module,only:&                                ! look-up values for the choice of method for the spatial representation of groundwater
  localColumn, & ! separate groundwater representation in each local soil column
  singleBasin    ! single groundwater store over the entire basin
-USE output_stats,only:allocStat,calcStats                   ! module for compiling output statistics
+USE output_stats,only:calcStats                             ! module for compiling output statistics
 USE globalData,only:nFreq,outFreq                           ! model output files
 USE globalData,only:ncid                                    ! file id of netcdf output file
 USE var_lookup,only:maxFreq                                 ! maximum # of output files 
@@ -450,7 +450,7 @@ do iStruct=1,size(structInfo)
   case('prog'); call allocGlobal(statProg_meta(:)%var_info,progStat,err,message)   ! model prognostic (state) variables
   case('diag'); call allocGlobal(statDiag_meta(:)%var_info,diagStat,err,message)   ! model diagnostic variables
   case('flux'); call allocGlobal(statFlux_meta(:)%var_info,fluxStat,err,message)   ! model fluxes
-  case('indx'); call allocGlobal(statFlux_meta(:)%var_info,indxStat,err,message)   ! index vars
+  case('indx'); call allocGlobal(statIndx_meta(:)%var_info,indxStat,err,message)   ! index vars
   case('bvar'); call allocGlobal(statBvar_meta(:)%var_info,bvarStat,err,message)   ! basin-average variables
   case default; cycle
  endselect  
@@ -996,7 +996,7 @@ do modelTimeStep=1,numtim
   call handle_err(err,message)
   end associate
  
- ! calc basin stats 
+  ! calc basin stats 
   call calcStats(bvarStat%gru(iGRU)%var(:),bvarStruct%gru(iGRU)%var(:),statBvar_meta,waterYearTimeStep,err,message); call handle_err(err,message)
 
   ! write basin-average variables

--- a/build/source/dshare/data_types.f90
+++ b/build/source/dshare/data_types.f90
@@ -65,13 +65,13 @@ MODULE data_types
  ! ***********************************************************************************************************
  ! define derived type for model variables, including name, decription, and units
  type,public :: var_info
-  character(len=64)                         :: varname  = 'empty'         ! variable name
-  character(len=128)                        :: vardesc  = 'empty'         ! variable description
-  character(len=64)                         :: varunit  = 'empty'         ! variable units
-  integer(i4b)                              :: vartype  = integerMissing  ! variable type 
-  logical(lgt),dimension(maxvarStat)        :: statFlag = .false.         ! statistic flag (on/off) 
-  integer(i4b)                              :: outFreq  = integerMissing  ! output file id # - each variable may be output to exaclty one of maxFreq output files 
-  integer(i4b),dimension(maxvarStat)        :: ncVarID  = integerMissing  ! netcdf variable id 
+  character(len=64)                      :: varname  = 'empty'         ! variable name
+  character(len=128)                     :: vardesc  = 'empty'         ! variable description
+  character(len=64)                      :: varunit  = 'empty'         ! variable units
+  integer(i4b)                           :: vartype  = integerMissing  ! variable type 
+  logical(lgt),dimension(maxvarStat)     :: statFlag = .false.         ! statistic flag (on/off) 
+  integer(i4b)                           :: outFreq  = integerMissing  ! output file id # - each variable may be output to exaclty one of maxFreq output files 
+  integer(i4b),dimension(maxvarStat)     :: ncVarID  = integerMissing  ! netcdf variable id 
  endtype var_info
 
  ! define extended data type (include indices to map onto parent data type)

--- a/build/source/dshare/outpt_stat.f90
+++ b/build/source/dshare/outpt_stat.f90
@@ -23,100 +23,9 @@ module output_stats
 USE nrtype
 implicit none
 private
-public :: allocStat
 public :: calcStats
 !public :: compileBasinStats
 contains
-
- ! ******************************************************************************************************
- ! public subroutine allocStat is called at beginning of simulation to allocate space for output statistics 
- ! ******************************************************************************************************
- subroutine allocStat(meta,stat,err,message)
- USE nrtype
- ! data structures
- USE globalData,only:gru_struc          ! gru struct 
- USE var_lookup,only:maxvarStat         ! number of different output statistics
- USE data_types,only:extended_info      ! meta type
- USE data_types,only:gru_doubleVec,  &  ! x%gru(:)%var(:)%dat (dp)
-                     gru_hru_intVec, &  ! x%gru(:)%var(:)%dat (dp)
-                     gru_hru_doubleVec  ! x%gru(:)%hru(:)%var(:)%dat (dp)
- implicit none
-
- ! dummies
- type(extended_info),intent(in)  :: meta(:)  ! meta structure
- class(*)      ,intent(out) :: stat     ! stats structure 
- integer(i4b)  ,intent(out) :: err      ! error code
- character(*)  ,intent(out) :: message  ! error message
-
- ! locals
- character(1024)            :: cmessage ! error message
- integer(i4b)               :: iVar     ! index var_info array 
- integer(i4b)               :: iGRU     ! loop through GRUs
- integer(i4b)               :: iHRU     ! loop through HRUs
-
- ! initialize error control
- err=0; message='allocStat/'
-
- ! loop through grus
- do iGRU = 1,size(gru_struc)
-
-  ! take different action ndepending on whether the type has HRUs
-  select type(stat)   
-   type is (gru_hru_intVec)
-    ! (1) allocate the GRU level structure
-    allocate(stat%gru(size(gru_struc))                           ,stat=err)
-    if (err.ne.0) then; message=trim(message)//'GUR allocate error'; return; endif;
-    ! (2) allocate the HRU level structure
-    allocate(stat%gru(iGRU)%hru(gru_struc(iGRU)%hruCount)        ,stat=err)
-    if (err.ne.0) then; message=trim(message)//'HRU allocate error'; return; endif;
-    ! (3) allocate the variable level structure
-    do iHRU = 1,gru_struc(iGRU)%hruCount
-     allocate(stat%gru(iGRU)%hru(iHRU)%var(size(meta))           ,stat=err)
-     if (err.ne.0) then; message=trim(message)//'VAR allocate error'; return; endif;
-     ! (4) allocate the data (statistics) level structure
-     do iVar = 1,size(meta)
-      allocate(stat%gru(iGRU)%hru(iHRU)%var(iVar)%dat(maxvarStat+1),stat=err)
-      if (err.ne.0) then; message=trim(message)//'STAT allocate error'; return; endif;
-     enddo ! ivar
-    enddo ! iHRU
-
-   type is (gru_hru_doubleVec)
-    ! (1) allocate the GRU level structure
-    allocate(stat%gru(size(gru_struc))                           ,stat=err)
-    if (err.ne.0) then; message=trim(message)//'GUR allocate error'; return; endif;
-    ! (2) allocate the HRU level structure
-    allocate(stat%gru(iGRU)%hru(gru_struc(iGRU)%hruCount)        ,stat=err)
-    if (err.ne.0) then; message=trim(message)//'HRU allocate error'; return; endif;
-    ! (3) allocate the variable level structure
-    do iHRU = 1,gru_struc(iGRU)%hruCount
-     allocate(stat%gru(iGRU)%hru(iHRU)%var(size(meta))           ,stat=err)
-     if (err.ne.0) then; message=trim(message)//'VAR allocate error'; return; endif;
-     ! (4) allocate the data (statistics) level structure
-     do iVar = 1,size(meta)
-      allocate(stat%gru(iGRU)%hru(iHRU)%var(iVar)%dat(maxvarStat+1),stat=err)
-      if (err.ne.0) then; message=trim(message)//'STAT allocate error'; return; endif;
-     enddo ! ivar
-    enddo ! iHRU
-
-   type is (gru_doubleVec)
-    ! (1) allocate the GRU level structure
-    allocate(stat%gru(size(gru_struc))                ,stat=err)
-    if (err.ne.0) then; message=trim(message)//'GRU allocate error (no GRU)'; return; endif;
-    ! (3) allocate the variable level structure
-    allocate(stat%gru(iGRU)%var(size(meta))           ,stat=err)
-    if (err.ne.0) then; message=trim(message)//'VAR allocate error (no HRU)'; return; endif;
-    ! (4) allocate the data (statistics) level structure
-    do iVar = 1,size(meta)
-     allocate(stat%gru(iGRU)%var(iVar)%dat(maxvarStat+1),stat=err)
-     if (err.ne.0) then; message=trim(message)//'STAT allocate error (no HRU)'; return; endif;
-    enddo ! ivar
-  endselect
-
- enddo ! GRU
-
- return
- end subroutine allocStat
-
 
  ! ******************************************************************************************************
  ! public subroutine calcStats is called at every model timestep to update/store output statistics 
@@ -141,6 +50,7 @@ contains
  ! internals
  character(256)                 :: cmessage         ! error message
  integer(i4b)                   :: iVar             ! index for varaiable loop
+ integer(i4b)                   :: pVar             ! index into parent structure
  integer(i4b)                   :: iFreq            ! index for frequency loop
  real(dp)                       :: tdata            ! dummy for pulling info from dat structure
 
@@ -152,10 +62,16 @@ contains
   ! only treat stats of scalars - all others handled separately
   if (meta(iVar)%varType==iLookVarType%outstat) then
 
-   selecttype (dat)
-    typeis (real(dp)); tdata = dat(meta(iVar)%ixParent)
-    typeis (dlength) ; tdata = dat(meta(iVar)%ixParent)%dat(1)
-    typeis (ilength) ; tdata = real(dat(meta(iVar)%ixParent)%dat(1))
+   ! don't do anything if var is not requested
+   if (meta(iVar)%outFreq<0) cycle
+
+   ! index into parent structure
+   pVar = meta(iVar)%ixParent
+
+   select type (dat)
+    type is (real(dp)); tdata = dat(pVar)
+    type is (dlength) ; tdata = dat(pVar)%dat(1)
+    type is (ilength) ; tdata = real(dat(pVar)%dat(1))
     class default;err=20;message=trim(message)//'dat type not found';return
    endselect
 
@@ -205,11 +121,12 @@ contains
 
  ! pull current frequency for normalization
  iFreq = meta%outFreq
+ if (iFreq<0) then; err=-20; message=trim(message)//'bad output file id# (outfreq)'; return; endif
 
  ! pack back into struc
- selecttype (stat)
-  typeis (ilength); tstat = real(stat%dat)
-  typeis (dlength); tstat = stat%dat
+ select type (stat)
+  type is (ilength); tstat = real(stat%dat)
+  type is (dlength); tstat = stat%dat
   class default;err=20;message=trim(message)//'stat type not found';return
  endselect
 
@@ -281,9 +198,9 @@ contains
  endif
 
  ! pack back into struc
- selecttype (stat)
-  typeis (ilength); stat%dat = int(tstat)
-  typeis (dlength); stat%dat = tstat
+ select type (stat)
+  type is (ilength); stat%dat = int(tstat)
+  type is (dlength); stat%dat = tstat
   class default;err=20;message=trim(message)//'stat type not found';return
  endselect
 

--- a/build/source/dshare/var_lookup.f90
+++ b/build/source/dshare/var_lookup.f90
@@ -672,6 +672,7 @@ MODULE var_lookup
   integer(i4b)    :: ifcSoil   = integerMissing ! interface soil variables
   integer(i4b)    :: ifcToto   = integerMissing ! interface, snow and soil
   integer(i4b)    :: routing   = integerMissing ! routing variables
+  integer(i4b)    :: outstat   = integerMissing ! output statistic
   integer(i4b)    :: unknown   = integerMissing ! cath-cal alternative type
  endtype iLook_varType
 
@@ -772,7 +773,7 @@ MODULE var_lookup
                                                                          11) 
 
  ! named variables in varibale type structure
- type(iLook_varType), public,parameter :: iLookVarType  =ilook_varType (  1,  2,  3,  4,  5,  6,  7,  8,  9, 10)
+ type(iLook_varType), public,parameter :: iLookVarType  =ilook_varType (  1,  2,  3,  4,  5,  6,  7,  8,  9, 10, 11)
 
  ! number of possible output statistics
  type(iLook_stat),    public,parameter :: iLookStat     =ilook_stat    (  1,  2,  3,  4,  5,  6,  7)
@@ -798,7 +799,7 @@ MODULE var_lookup
  ! (Y) define ancillary look-up structures
  ! ***********************************************************************************************************
 
- integer(i4b), public          :: childFLUX_MEAN(maxvarFlux)  ! index of the child data structure: mean flux
+ integer(i4b),allocatable,save,public   :: childFLUX_MEAN(:)  ! index of the child data structure: mean flux
 
 
 END MODULE var_lookup

--- a/build/source/engine/allocspace.f90
+++ b/build/source/engine/allocspace.f90
@@ -155,6 +155,7 @@ contains
  USE globalData,only: gru_struc                    ! gru-hru mapping structures
  implicit none
  ! input
+! class(*),intent(in)             :: metaStruct(:)  ! metadata structure
  type(var_info),intent(in)       :: metaStruct(:)  ! metadata structure
  ! output
  class(*),intent(out)            :: dataStruct     ! data structure
@@ -255,14 +256,15 @@ contains
  end do gruLoop ! loop through GRUs
 
  ! * allocate local data structures where there is no spatial dimension
- select type(dataStruct)
-  type is (var_i);         call allocLocal(metaStruct,dataStruct,err=err,message=cmessage) 
-  type is (var_d);         call allocLocal(metaStruct,dataStruct,err=err,message=cmessage)
-  type is (var_ilength);   call allocLocal(metaStruct,dataStruct,err=err,message=cmessage)
-  type is (var_dlength);   call allocLocal(metaStruct,dataStruct,err=err,message=cmessage)
-  ! check identified the data type
-  class default; if(.not.spatial)then; err=20; message=trim(message)//'unable to identify derived data type'; return; endif
- end select
+  select type(dataStruct)
+   type is (var_i);         call allocLocal(metaStruct,dataStruct,err=err,message=cmessage) 
+   type is (var_d);         call allocLocal(metaStruct,dataStruct,err=err,message=cmessage)
+   type is (var_ilength);   call allocLocal(metaStruct,dataStruct,err=err,message=cmessage)
+   type is (var_dlength);   call allocLocal(metaStruct,dataStruct,err=err,message=cmessage)
+   ! check identified the data type
+   class default; if(.not.spatial)then; err=20; message=trim(message)//'unable to identify derived data type'; return; endif
+  end select
+ 
  ! error check
  if(err/=0)then; err=20; message=trim(message)//trim(cmessage); return; endif
 
@@ -330,6 +332,7 @@ contains
   type is (var_dlength); call allocateDat_dp( metaStruct,nSnow,nSoil,nLayers,dataStruct,err,cmessage) 
   class default; err=20; message=trim(message)//'unable to identify derived data type for the data dimension'; return
  end select
+ 
  ! check errors
  if(err/=0)then; message=trim(message)//trim(cmessage); return; endif
 
@@ -341,6 +344,7 @@ contains
  subroutine allocateDat_dp(metadata,nSnow,nSoil,nLayers, & ! input
                            varData,err,message)            ! output
  USE var_lookup,only:iLookVarType                 ! look up structure for variable typed
+ USE var_lookup,only:maxvarStat                   ! allocation dimension (stats)
  USE get_ixName_module,only:get_varTypeName       ! to access type strings for error messages
  implicit none
  ! input variables
@@ -354,11 +358,15 @@ contains
  character(*),intent(out)          :: message     ! error message
  ! local variables
  integer(i4b)                      :: iVar        ! variable index
+ integer(i4b)                      :: nVars       ! number of variables in the metadata structure
  ! initialize error control
  err=0; message='allocateDat_dp/'
 
+ ! get the number of variables in the metadata structure
+ nVars = size(metadata)
+
  ! loop through variables in the data structure
- do iVar=1,size(metadata)
+ do iVar=1,nVars
 
   ! check allocated
   if(allocated(varData%var(iVar)%dat))then
@@ -377,9 +385,11 @@ contains
     case(iLookVarType%ifcSoil); allocate(varData%var(iVar)%dat(0:nSoil),stat=err)
     case(iLookVarType%ifcToto); allocate(varData%var(iVar)%dat(0:nLayers),stat=err)
     case(iLookVarType%routing); allocate(varData%var(iVar)%dat(nTimeDelay),stat=err)
+    case(iLookVarType%outstat); allocate(varData%var(iVar)%dat(maxvarStat+1),stat=err)
     case(iLookVarType%unknown); allocate(varData%var(iVar)%dat(0),stat=err)  ! unknown=special (and valid) case that is allocated later (initialize with zero-length vector)
     case default
-     err=40; message=trim(message)//"unknownVariableType[name='"//trim(metadata(iVar)%varname)//"'; type='"//trim(get_varTypeName(metadata(iVar)%vartype))//"']"
+print*,'allocspace.f90 (447):', metadata(iVar)
+     err=40; message=trim(message)//"1. unknownVariableType[name='"//trim(metadata(iVar)%varname)//"'; type='"//trim(get_varTypeName(metadata(iVar)%vartype))//"']"
      return
    endselect
    ! check error
@@ -398,6 +408,7 @@ contains
  subroutine allocateDat_int(metadata,nSnow,nSoil,nLayers, & ! input
                             varData,err,message)            ! output
  USE var_lookup,only:iLookVarType                 ! look up structure for variable typed
+ USE var_lookup,only:maxvarStat                   ! allocation dimension (stats)
  USE get_ixName_module,only:get_varTypeName       ! to access type strings for error messages
  implicit none
  ! input variables
@@ -411,11 +422,15 @@ contains
  character(*),intent(out)          :: message     ! error message
  ! local variables
  integer(i4b)                      :: iVar        ! variable index
+ integer(i4b)                      :: nVars       ! number of variables in the metadata structure
  ! initialize error control
  err=0; message='allocateDat_int/'
 
+ ! get the number of variables in the metadata structure
+ nVars = size(metadata)
+
  ! loop through variables in the data structure
- do iVar=1,size(metadata)
+ do iVar=1,nVars
 
   ! check allocated
   if(allocated(varData%var(iVar)%dat))then
@@ -434,8 +449,9 @@ contains
     case(iLookVarType%ifcSoil); allocate(varData%var(iVar)%dat(0:nSoil),stat=err)
     case(iLookVarType%ifcToto); allocate(varData%var(iVar)%dat(0:nLayers),stat=err)
     case(iLookVarType%routing); allocate(varData%var(iVar)%dat(nTimeDelay),stat=err)
+    case(iLookVarType%outstat); allocate(varData%var(iVar)%dat(maxvarStat+1),stat=err)
     case(iLookVarType%unknown); allocate(varData%var(iVar)%dat(0),stat=err)  ! unknown=special (and valid) case that is allocated later (initialize with zero-length vector)
-    case default; err=40; message=trim(message)//"unknownVariableType[name='"//trim(metadata(iVar)%varname)//"'; type='"//trim(get_varTypeName(metadata(iVar)%vartype))//"']"; print*,metadata(iVar)%vartype,metadata(iVar)%varName; return
+    case default; err=40; message=trim(message)//"unknownVariableType[name='"//trim(metadata(iVar)%varname)//"'; type='"//trim(get_varTypeName(metadata(iVar)%vartype))//"']"; return
    endselect
    ! check error
    if(err/=0)then; err=20; message=trim(message)//'problem allocating variable '//trim(metadata(iVar)%varname); return; endif

--- a/build/source/engine/childStruc.f90
+++ b/build/source/engine/childStruc.f90
@@ -42,7 +42,7 @@ contains
  logical(lgt),intent(in)                     :: mask(:)             ! variables desired
  ! output variables
  type(extended_info),allocatable,intent(out) :: metaChild(:)        ! child metadata structure
- integer(i4b),intent(out)                    :: parent2child_map(:) ! index of the child variable
+ integer(i4b),allocatable,intent(out)        :: parent2child_map(:) ! index of the child variable
  integer(i4b),intent(out)                    :: err                 ! error code
  character(*),intent(out)                    :: message             ! error message
  ! local variables
@@ -74,7 +74,9 @@ contains
  ! copy across the metadata from the parent structure
  metaChild(:)%var_info = metaParent(metaChild(:)%ixParent)
 
- ! put the child indices in the childFLUX_MEAN vector
+ ! allows to map from the parent to the child - must carry this around outside
+ if(allocated(parent2child_map)) then; err=20; message=trim(message)//'child map already allocated'; return; endif; 
+ allocate(parent2child_map(nParent))
  parent2child_map(:) = integerMissing
  parent2child_map(metaChild(:)%ixParent) = arth(1,1,nChild)
 

--- a/build/source/netcdf/modelwrite.f90
+++ b/build/source/netcdf/modelwrite.f90
@@ -91,7 +91,7 @@ contains
  ! **************************************************************************************
  ! public subroutine writeData: write model time-dependent data
  ! **************************************************************************************
- subroutine writeData(modelTimestep,outputTimestep,meta,stat,dat,indx,iHRU,err,message)
+ subroutine writeData(modelTimestep,outputTimestep,meta,stat,dat,map,indx,iHRU,err,message)
  USE data_types,only:var_info,dlength,ilength       ! type structures for passing
  USE var_lookup,only:maxVarStat                     ! index into stats structure
  USE var_lookup,only:iLookVarType                   ! index into type structure
@@ -107,6 +107,7 @@ contains
  class(*)      ,intent(in)     :: stat(:)           ! stats data
  class(*)      ,intent(in)     :: dat(:)            ! timestep data
  type(ilength) ,intent(in)     :: indx(:)           ! index data
+ integer(i4b)  ,intent(in)     :: map(:)            ! map into stats child struct
  integer(i4b)  ,intent(in)     :: iHRU              ! hydrologic response unit
  integer(i4b)  ,intent(in)     :: modelTimestep     ! model time step
  integer(i4b)  ,intent(in)     :: outputTimestep(:) ! output time step
@@ -174,9 +175,9 @@ contains
      if (meta(iVar)%varType==iLookVarType%scalarv) then
        selecttype(stat)
         typeis (ilength)
-         err = nf90_put_var(ncid(iFreq),meta(iVar)%ncVarID(iStat),(/stat(iVar)%dat(iStat)/),start=(/iHRU,outputTimestep(iFreq)/),count=(/1,1/))
+         err = nf90_put_var(ncid(iFreq),meta(iVar)%ncVarID(iStat),(/stat(map(iVar))%dat(iStat)/),start=(/iHRU,outputTimestep(iFreq)/),count=(/1,1/))
         typeis (dlength)
-         err = nf90_put_var(ncid(iFreq),meta(iVar)%ncVarID(iStat),(/stat(iVar)%dat(iStat)/),start=(/iHRU,outputTimestep(iFreq)/),count=(/1,1/))
+         err = nf90_put_var(ncid(iFreq),meta(iVar)%ncVarID(iStat),(/stat(map(iVar))%dat(iStat)/),start=(/iHRU,outputTimestep(iFreq)/),count=(/1,1/))
         class default; err=20; message=trim(message)//'stats must be scalarv and either ilength of dlength'; return
        endselect  ! stat 
      else
@@ -217,7 +218,7 @@ contains
  ! **************************************************************************************
  ! public subroutine writeBasin: write basin-average variables
  ! **************************************************************************************
- subroutine writeBasin(modelTimestep,outputTimestep,meta,stat,dat,indx,err,message)
+ subroutine writeBasin(modelTimestep,outputTimestep,meta,stat,dat,map,indx,err,message)
  USE data_types,only:var_info,dlength,ilength       ! type structures for passing
  USE var_lookup,only:maxVarStat                     ! index into stats structure
  USE var_lookup,only:iLookVarType                   ! index into type structure
@@ -233,6 +234,7 @@ contains
  type(dlength) ,intent(in)     :: stat(:)           ! stats data
  type(dlength) ,intent(in)     :: dat(:)            ! timestep data
  type(ilength) ,intent(in)     :: indx(:)           ! index data
+ integer(i4b)  ,intent(in)     :: map(:)            ! map into stats child struct
  integer(i4b)  ,intent(in)     :: modelTimestep     ! model time step
  integer(i4b)  ,intent(in)     :: outputTimestep(:) ! output time step
  integer(i4b)  ,intent(out)    :: err               ! error code
@@ -263,11 +265,11 @@ contains
      selectcase (meta(iVar)%varType)
 
       case (iLookVarType%scalarv)
-       err = nf90_put_var(ncid(iFreq),meta(iVar)%ncVarID(iStat),(/stat(iVar)%dat(iStat)/),start=(/outputTimestep(iFreq)/),count=(/1/))
+       err = nf90_put_var(ncid(iFreq),meta(iVar)%ncVarID(iStat),(/stat(map(iVar))%dat(iStat)/),start=(/outputTimestep(iFreq)/),count=(/1/))
 
       case (iLookVarType%routing)
        if (modelTimestep==1) then
-        err = nf90_put_var(ncid(iFreq),meta(iVar)%ncVarID(iStat),(/dat(iVar)%dat/),start=(/1/),count=(/1000/))
+        err = nf90_put_var(ncid(iFreq),meta(iVar)%ncVarID(iStat),(/dat(map(iVar))%dat/),start=(/1/),count=(/1000/))
        endif
 
       case default

--- a/build/source/netcdf/modelwrite.f90
+++ b/build/source/netcdf/modelwrite.f90
@@ -66,16 +66,16 @@ contains
 
   ! write data
   if (iHRU.ne.integerMissing) then
-   selecttype (dat)
-    typeis (integer)
+   select type (dat)
+    type is (integer)
      err = nf90_put_var(ncid(modelTime),meta(iVar)%ncVarID(iLookStat%inst),(/dat(iVar)/),start=(/iHRU/),count=(/1/))
-    typeis (real(dp))
+    type is (real(dp))
      err = nf90_put_var(ncid(modelTime),meta(iVar)%ncVarID(iLookStat%inst),(/dat(iVar)/),start=(/iHRU/),count=(/1/))
     class default; err=20; message=trim(message)//'unkonwn dat type (with HRU)'; return
    endselect
   else
-   selecttype (dat)
-    typeis (real(dp))
+   select type (dat)
+    type is (real(dp))
      err = nf90_put_var(ncid(modelTime),meta(iVar)%ncVarID(iLookStat%inst),(/dat(iVar)/),start=(/1/),count=(/1/))
     class default; err=20; message=trim(message)//'unkonwn dat type (no HRU)'; return
    endselect
@@ -152,8 +152,8 @@ contains
 
     ! handle time first
     if (meta(iVar)%varName=='time') then    
-     selecttype(stat)
-      typeis (dlength)
+     select type(stat)
+      type is (dlength)
        err = nf90_inq_varid(ncid(iFreq),trim(meta(iVar)%varName),ncVarID) 
        call netcdf_err(err,message); if (err/=0) return
        err = nf90_put_var(ncid(iFreq),ncVarID,(/stat(iVar)%dat(iLookStat%inst)/),start=(/outputTimestep(iFreq)/),count=(/1,1/))
@@ -173,16 +173,16 @@ contains
 
      ! stats/dats output - select data type
      if (meta(iVar)%varType==iLookVarType%scalarv) then
-       selecttype(stat)
-        typeis (ilength)
+       select type(stat)
+        type is (ilength)
          err = nf90_put_var(ncid(iFreq),meta(iVar)%ncVarID(iStat),(/stat(map(iVar))%dat(iStat)/),start=(/iHRU,outputTimestep(iFreq)/),count=(/1,1/))
-        typeis (dlength)
+        type is (dlength)
          err = nf90_put_var(ncid(iFreq),meta(iVar)%ncVarID(iStat),(/stat(map(iVar))%dat(iStat)/),start=(/iHRU,outputTimestep(iFreq)/),count=(/1,1/))
         class default; err=20; message=trim(message)//'stats must be scalarv and either ilength of dlength'; return
        endselect  ! stat 
      else
-      selecttype (dat)
-       typeis (dlength)
+      select type (dat)
+       type is (dlength)
         selectcase (meta(iVar)%varType)
          case(iLookVarType%wLength); err = nf90_put_var(ncid(iFreq),meta(iVar)%ncVarID(iStat),(/dat(iVar)%dat/),start=(/iHRU,1,outputTimestep(iFreq)/),count=(/1,maxSpectral,1/))
          case(iLookVarType%midToto); err = nf90_put_var(ncid(iFreq),meta(iVar)%ncVarID(iStat),(/dat(iVar)%dat/),start=(/iHRU,midTotoStartIndex/),count=(/1,nLayers/))
@@ -192,7 +192,7 @@ contains
          case(iLookVarType%ifcSnow); err = nf90_put_var(ncid(iFreq),meta(iVar)%ncVarID(iStat),(/dat(iVar)%dat/),start=(/iHRU,ifcSnowStartIndex/),count=(/1,nSnow/))
          case(iLookVarType%ifcSoil); err = nf90_put_var(ncid(iFreq),meta(iVar)%ncVarID(iStat),(/dat(iVar)%dat/),start=(/iHRU,ifcSoilStartIndex/),count=(/1,nSoil/))
         endselect ! vartype
-       typeis (ilength)
+       type is (ilength)
         selectcase (meta(iVar)%varType)
          case(iLookVarType%wLength); err = nf90_put_var(ncid(iFreq),meta(iVar)%ncVarID(iStat),(/dat(iVar)%dat/),start=(/iHRU,1,outputTimestep(iFreq)/),count=(/1,maxSpectral,1/))
          case(iLookVarType%midToto); err = nf90_put_var(ncid(iFreq),meta(iVar)%ncVarID(iStat),(/dat(iVar)%dat/),start=(/iHRU,midTotoStartIndex/),count=(/1,nLayers/))
@@ -218,7 +218,7 @@ contains
  ! **************************************************************************************
  ! public subroutine writeBasin: write basin-average variables
  ! **************************************************************************************
- subroutine writeBasin(modelTimestep,outputTimestep,meta,stat,dat,map,indx,err,message)
+ subroutine writeBasin(modelTimestep,outputTimestep,meta,stat,dat,map,err,message)
  USE data_types,only:var_info,dlength,ilength       ! type structures for passing
  USE var_lookup,only:maxVarStat                     ! index into stats structure
  USE var_lookup,only:iLookVarType                   ! index into type structure
@@ -233,7 +233,6 @@ contains
  type(var_info),intent(in)     :: meta(:)           ! meta data
  type(dlength) ,intent(in)     :: stat(:)           ! stats data
  type(dlength) ,intent(in)     :: dat(:)            ! timestep data
- type(ilength) ,intent(in)     :: indx(:)           ! index data
  integer(i4b)  ,intent(in)     :: map(:)            ! map into stats child struct
  integer(i4b)  ,intent(in)     :: modelTimestep     ! model time step
  integer(i4b)  ,intent(in)     :: outputTimestep(:) ! output time step


### PR DESCRIPTION
This update merges the allocate routines used to initialize both the primary model variables (e.g., `forceStruct`, etc.), and the output statistics variables (e.g., `forceStat`, etc.). It also fixes a couple minor bugs in the statistics output logic.