### PR TITLE
Feature/print git version info

### DIFF
--- a/build/Makefile
+++ b/build/Makefile
@@ -259,7 +259,7 @@ DRIVER__EX = summa.exe
 VERSIONFILE = $(DRIVER_DIR)/summaversion.inc
 VERSION = $(shell git tag | sed 's/v//')
 BULTTIM = $(shell date)
-GITBRCH = $(shell git describe --long --dirty --all --always | sed -e's/heads\///')
+GITBRCH = $(shell git describe --long --all --always | sed -e's/heads\///')
 GITHASH = $(shell git rev-parse HEAD)
 
 #========================================================================

--- a/build/source/driver/multi_driver.f90
+++ b/build/source/driver/multi_driver.f90
@@ -1085,13 +1085,13 @@ contains
   ! print versions if needed
   if (trim(argString(iArgument)) == '-v' .or. trim(argString(iArgument)) == '--version') then  
    ! print version numbers
-   print "(70('-'))", ''
+   print "(70('-'))", 
    print "(A)", '     SUMMA - Structure for Unifying Multiple Modeling Alternatives    '
    print "(28x,2A)", 'Version: ', trim(summaVersion)
    print "(15x,2A)", 'Build Time: ', trim(buildTime)
    print "(8x,2A)",  'Git Branch: ', trim(gitBranch)
    print "(8x,2A)",  'Git Hash:   ', trim(gitHash)
-   print "(70('-'))", ''
+   print "(70('-'))", 
    if (nArgument == 1) stop
   end if 
  end do  

--- a/build/source/driver/summaversion.inc
+++ b/build/source/driver/summaversion.inc
@@ -1,4 +1,4 @@
  character(len=64), parameter     :: summaVersion = '1.0.0'
- character(len=64), parameter     :: gitBranch = 'feature/printGitVersionInfo-0-g8413d17-dirty'
- character(len=64), parameter     :: gitHash = '8413d177da3afb49aa0744b2de8917799e6522af'
- character(len=64), parameter     :: buildTime = 'Tue, Oct 18, 2016  8:26:36 PM'
+ character(len=64), parameter     :: gitBranch = 'feature/printGitVersionInfo-0-g71f9947-dirty'
+ character(len=64), parameter     :: gitHash = '71f9947085cd07f01081a97dcc66b5f1548c5c93'
+ character(len=64), parameter     :: buildTime = 'Tue, Oct 18, 2016  8:53:20 PM'

--- a/build/source/driver/summaversion.inc
+++ b/build/source/driver/summaversion.inc
@@ -1,4 +1,4 @@
  character(len=64), parameter     :: summaVersion = '1.0.0'
- character(len=64), parameter     :: gitBranch = 'feature/printGitVersionInfo-0-g71f9947-dirty'
- character(len=64), parameter     :: gitHash = '71f9947085cd07f01081a97dcc66b5f1548c5c93'
- character(len=64), parameter     :: buildTime = 'Tue, Oct 18, 2016  8:53:20 PM'
+ character(len=64), parameter     :: gitBranch = 'feature/printGitVersionInfo-0-g81e4d72'
+ character(len=64), parameter     :: gitHash = '81e4d72626fa834efd7c5f8876f314d2ac3f78d3'
+ character(len=64), parameter     :: buildTime = 'Tue, Oct 18, 2016  9:04:23 PM'


### PR DESCRIPTION
PR #188  was accidentally closed.

update after @bartnijssen's comment:
 1 the version number is now generated from `git tag`.
 2 the built failed because on travis `getVersion.bash` is not executable due to permission issue. It can be fixed by `chmod +x`. But instead I moved the commands of getting version information to the Makefile. Now it passed travis test.   
