### PR TITLE
Fix to Makefile so that sed -i works on OS X (and BSD)

### DIFF
--- a/build/Makefile
+++ b/build/Makefile
@@ -320,10 +320,10 @@ check:
 
 # update version information
 update_version:
-	sed -i "s|character(len=64), parameter     :: summaVersion.*|character(len=64), parameter     :: summaVersion = '${VERSION}'|" $(VERSIONFILE)
-	sed -i "s|character(len=64), parameter     :: buildTime.*|character(len=64), parameter     :: buildTime = '${BULTTIM}'|" $(VERSIONFILE)
-	sed -i "s|character(len=64), parameter     :: gitBranch.*|character(len=64), parameter     :: gitBranch = '${GITBRCH}'|" $(VERSIONFILE)
-	sed -i "s|character(len=64), parameter     :: gitHash.*|character(len=64), parameter     :: gitHash = '${GITHASH}'|" $(VERSIONFILE)
+	sed -i '' "s|character(len=64), parameter     :: summaVersion.*|character(len=64), parameter     :: summaVersion = '${VERSION}'|" $(VERSIONFILE)
+	sed -i '' "s|character(len=64), parameter     :: buildTime.*|character(len=64), parameter     :: buildTime = '${BULTTIM}'|" $(VERSIONFILE)
+	sed -i '' "s|character(len=64), parameter     :: gitBranch.*|character(len=64), parameter     :: gitBranch = '${GITBRCH}'|" $(VERSIONFILE)
+	sed -i '' "s|character(len=64), parameter     :: gitHash.*|character(len=64), parameter     :: gitHash = '${GITHASH}'|" $(VERSIONFILE)
 
 # compile Noah-MP routines
 compile_noah:


### PR DESCRIPTION
http://stackoverflow.com/questions/16745988/sed-command-works-fine-on-ubuntu-but-not-mac

Ubuntu ships with GNU sed, where the suffix for the -i option is optional. OS X ships with BSD sed, where the suffix is mandatory. Try sed -i ''

