### PR TITLE
Bug fix/echo version file

### DIFF
--- a/build/Makefile
+++ b/build/Makefile
@@ -322,10 +322,10 @@ check:
 
 # update version information
 update_version:
-	sed -i '' "s|character(len=64), parameter     :: summaVersion.*|character(len=64), parameter     :: summaVersion = '${VERSION}'|" $(VERSIONFILE)
-	sed -i '' "s|character(len=64), parameter     :: buildTime.*|character(len=64), parameter     :: buildTime = '${BULTTIM}'|" $(VERSIONFILE)
-	sed -i '' "s|character(len=64), parameter     :: gitBranch.*|character(len=64), parameter     :: gitBranch = '${GITBRCH}'|" $(VERSIONFILE)
-	sed -i '' "s|character(len=64), parameter     :: gitHash.*|character(len=64), parameter     :: gitHash = '${GITHASH}'|" $(VERSIONFILE)
+	echo "character(len=64), parameter     :: summaVersion = '${VERSION}'" > $(VERSIONFILE)
+	echo "character(len=64), parameter     :: buildTime = '${BULTTIM}'" >> $(VERSIONFILE)
+	echo "character(len=64), parameter     :: gitBranch = '${GITBRCH}'" >> $(VERSIONFILE)
+	echo "character(len=64), parameter     :: gitHash = '${GITHASH}'" >> $(VERSIONFILE)
 
 # compile Noah-MP routines
 compile_noah:

--- a/build/source/driver/multi_driver.f90
+++ b/build/source/driver/multi_driver.f90
@@ -1077,7 +1077,7 @@ contains
  integer(i4b)                     :: nArgument                  ! number of command line arguments 
  character(len=256),allocatable   :: argString(:)               ! string to store command line arguments
  integer(i4b)                     :: nLocalArgument             ! number of command line arguments to read for a switch
-
+ character(len=70), parameter     :: spaces = ''
  nArgument = command_argument_count()   
  ! check numbers of command-line arguments and obtain all arguments 
  if (nArgument < 1) then 
@@ -1090,13 +1090,14 @@ contains
   ! print versions if needed
   if (trim(argString(iArgument)) == '-v' .or. trim(argString(iArgument)) == '--version') then  
    ! print version numbers
-   print "(70('-'),A)", ''
+
+   print "(A)", '----------------------------------------------------------------------'
    print "(A)", '     SUMMA - Structure for Unifying Multiple Modeling Alternatives    '
-   print "(28x,2A)", 'Version: ', trim(summaVersion)
-   print "(15x,2A)", 'Build Time: ', trim(buildTime)
-   print "(8x,2A)",  'Git Branch: ', trim(gitBranch)
-   print "(8x,2A)",  'Git Hash:   ', trim(gitHash)
-   print "(70('-'),A)", ''
+   print "(A)", spaces(1:int((70 - len_trim(summaVersion) - 9) / 2))//'Version: '   //trim(summaVersion)
+   print "(A)", spaces(1:int((70 - len_trim(buildTime) - 12) / 2))  //'Build Time: '//trim(buildTime)
+   print "(A)", spaces(1:int((70 - len_trim(gitBranch) - 12) / 2))  //'Git Branch: '//trim(gitBranch)
+   print "(A)", spaces(1:int((70 - len_trim(gitHash) - 10) / 2))    //'Git Hash: '  //trim(gitHash)
+   print "(A)", '----------------------------------------------------------------------'
    if (nArgument == 1) stop
   end if 
  end do  

--- a/build/source/driver/multi_driver.f90
+++ b/build/source/driver/multi_driver.f90
@@ -1090,13 +1090,13 @@ contains
   ! print versions if needed
   if (trim(argString(iArgument)) == '-v' .or. trim(argString(iArgument)) == '--version') then  
    ! print version numbers
-   print "(70('-'))", 
+   print "(70('-'),A)", ''
    print "(A)", '     SUMMA - Structure for Unifying Multiple Modeling Alternatives    '
    print "(28x,2A)", 'Version: ', trim(summaVersion)
    print "(15x,2A)", 'Build Time: ', trim(buildTime)
    print "(8x,2A)",  'Git Branch: ', trim(gitBranch)
    print "(8x,2A)",  'Git Hash:   ', trim(gitHash)
-   print "(70('-'))", 
+   print "(70('-'),A)", ''
    if (nArgument == 1) stop
   end if 
  end do  
@@ -1111,11 +1111,6 @@ contains
  do iArgument = 1,nArgument
   if (nLocalArgument>0) then; nLocalArgument = nLocalArgument -1; cycle; end if ! skip the arguments have been read 
   select case (trim(argString(iArgument)))
-
-   case ('-c', '--continue') ! TODO: this option will be deprecated after the explicit Euler and split operator solutions are implemented
-    nLocalArgument = 0
-    resumeFailSolver = .true.
-    print "(A)", "Simulation will continue even if the solver does NOT converge."
 
    case ('-m', '--master')
     ! update arguments
@@ -1144,7 +1139,7 @@ contains
     nHRU=1; nGRU=1                          ! nHRU and nGRU are both one in this case
     ! examines the checkHRU is correct 
     if (checkHRU<1) then
-     call handle_err(1,"illegal checkHRU specification; type 'summa.exe --help' for correct usage") 
+     call handle_err(1,"illegal iHRU specification; type 'summa.exe --help' for correct usage") 
     else
      print '(A)',' Single-HRU run activated. HRU '//trim(argString(iArgument+1))//' is selected for simulation.'
     end if
@@ -1225,8 +1220,8 @@ contains
  print "(A)",  ' -s --suffix        Add fileSuffix to the output files'
  print "(A)",  ' -g --gru           Run a subset of countGRU GRUs starting from index startGRU'
  print "(A)",  ' -h --hru           Run a single HRU with index of iHRU'
- print "(A)",  ' -r --restart       Define frequency [y,m,d] to write restart files'
- print "(A)",  ' -p --progress      Define frequency [m,d,h] to print progress'
+ print "(A)",  ' -r --restart       Define frequency [y,m,d,never] to write restart files'
+ print "(A)",  ' -p --progress      Define frequency [m,d,h,never] to print progress'
  print "(A)",  ' -v --version       Display version infotmation of the current built'
  stop 
  end subroutine printCommandHelp

--- a/build/source/driver/summaversion.inc
+++ b/build/source/driver/summaversion.inc
@@ -1,4 +1,0 @@
- character(len=64), parameter     :: summaVersion = '1.0.0'
- character(len=64), parameter     :: gitBranch = 'feature/printGitVersionInfo-0-g81e4d72'
- character(len=64), parameter     :: gitHash = '81e4d72626fa834efd7c5f8876f314d2ac3f78d3'
- character(len=64), parameter     :: buildTime = 'Tue, Oct 18, 2016  9:04:23 PM'


### PR DESCRIPTION
untrack the file containing git version information because it changes after every `git commit` or `make`. therefore, the file is created (`echo`) instead of replacing (`sed`) it.

remove deprecated command line options.

center align lines of version info