### PR TITLE
Docker

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,24 @@
+FROM phusion/baseimage:0.9.19
+
+USER root
+
+RUN apt-get update && \
+    add-apt-repository ppa:ubuntu-toolchain-r/test && \
+    apt-get update && \
+    apt-get install -y --no-install-recommends \
+    build-essential \
+    libnetcdff-dev \
+    netcdf-bin \
+    liblapack-dev \
+    gfortran-6 \
+    gcc && apt-get clean
+
+ENV FC gfortran-6
+ENV F_MASTER /code
+ENV NCDF_PATH /usr
+ENV LD_LIBRARY_PATH ${NCDF_PATH}/lib
+
+WORKDIR /code
+ADD . /code
+
+RUN make -C build/ -f Makefile

--- a/build/Makefile
+++ b/build/Makefile
@@ -13,11 +13,11 @@
 
 # Define core directory below which everything resides. This is the
 # parent directory of the 'build' directory
-F_MASTER =
+##F_MASTER =
 
 # Define the Fortran Compiler. If you are using gfortran, then this needs
 # to be version 4.8 or higher
-FC =
+##FC =
 
 # Define the NetCDF and LAPACK libraries and path to include files. Note
 # that the default paths defined are those that work for our compilers

--- a/build/Makefile
+++ b/build/Makefile
@@ -43,7 +43,7 @@ endif
 # Ubuntu gfortran compiler tested with 4.6 and higher
 # also used for the travis build
 ifeq "$(FC)" "gfortran-6"
- NCDF_PATH = /usr/local
+ NCDF_PATH ?= /usr/local
  LAPK_PATH = /usr
  # define the lapack libraries
  LIBLAPACK = -L$(LAPK_PATH)/lib -llapack -lblas

--- a/ci/summa_install_utils
+++ b/ci/summa_install_utils
@@ -78,9 +78,9 @@ function summa_before_install {
 function summa_install {
     echo summa_install
     cd ${TRAVIS_BUILD_DIR}
-    sed -i -e "s/FC =.*/FC = gfortran-6/" build/Makefile
-    sed -i -e "s|F_MASTER =.*|F_MASTER = ${TRAVIS_BUILD_DIR}|" build/Makefile
-    sed -i -e "s|NCDF_PATH =.*|NCDF_PATH = ${INSTALLDIR}|" build/Makefile
+    export FC=gfortran-6
+    export F_MASTER=${TRAVIS_BUILD_DIR}
+    export NCDF_PATH=${INSTALLDIR}
     make -C build/ -f Makefile &> make.log
 }
 


### PR DESCRIPTION
We (@jirikuncar and I) used a minimalistic ubuntu base image and made a few changes to the makefile so that it can run in the docker image without any modifications. 
Summa actually compiles now using the native netcdf libraries, so the ci/summa_install_utils is not needed for that. We made changes there while trying to use it, but found a simpler solution. 
To create the docker image, just run `docker build .` 