### PR TITLE
Adjust canopy windspeed and resistance contribution with snow depth

### DIFF
--- a/build/source/engine/vegNrgFlux.f90
+++ b/build/source/engine/vegNrgFlux.f90
@@ -2109,7 +2109,7 @@ contains
  if(computeVegFlux) then ! (if vegetation is exposed)
 
   ! ***** identify zero plane displacement, roughness length, and surface temperature for the canopy (m)
-  ! First, calculate offset from snow depth - use these to 
+  ! First, calculate offset from snow depth - use these to
   ! scale wind profiles and resistances
   heightCanopyTopAboveSnow = heightCanopyTop - snowDepth
   heightCanopyBottomAboveSnow = max(heightCanopyBottom - snowDepth, 0.0_dp)
@@ -2190,7 +2190,7 @@ contains
 
   ! compute windspeed at the top of the canopy (m s-1)
   ! NOTE: stability corrections cancel out
-  windConvFactorTop = log((heightCanopyTopAboveSnow - zeroPlaneDisplacement)/z0Canopy) / log((mHeight - zeroPlaneDisplacement)/z0Canopy)
+  windConvFactorTop = log((heightCanopyTopAboveSnow - zeroPlaneDisplacement)/z0Canopy) / log((mHeight - snowDepth - zeroPlaneDisplacement)/z0Canopy)
   windspdCanopyTop  = windspd*windConvFactorTop
 
   ! compute the windspeed reduction
@@ -2199,7 +2199,7 @@ contains
 
   ! compute windspeed at the bottom of the canopy (m s-1)
   referenceHeight      = max(heightCanopyBottomAboveSnow, z0Ground)
-  windConvFactorBottom = exp(-windReductionFactor*(1._dp - referenceHeight/heightCanopyTop))
+  windConvFactorBottom = exp(-windReductionFactor*(1._dp - (referenceHeight/heightCanopyTopAboveSnow)))
   windspdCanopyBottom  = windspdCanopyTop*windConvFactorBottom
 
   ! compute the leaf boundary layer resistance (s m-1)

--- a/build/source/engine/vegNrgFlux.f90
+++ b/build/source/engine/vegNrgFlux.f90
@@ -2188,7 +2188,7 @@ contains
   canopyResistance = 1._dp/(sfc2AtmExchangeCoeff_canopy*windspd)
   if(canopyResistance < 0._dp)then; err=20; message=trim(message)//'canopy resistance < 0'; return; end if
 
-  ! compute windspeed at the top of the canopy (m s-1)
+  ! compute windspeed at the top of the canopy above snow depth (m s-1)
   ! NOTE: stability corrections cancel out
   windConvFactorTop = log((heightCanopyTopAboveSnow - zeroPlaneDisplacement)/z0Canopy) / log((mHeight - snowDepth - zeroPlaneDisplacement)/z0Canopy)
   windspdCanopyTop  = windspd*windConvFactorTop
@@ -2197,7 +2197,7 @@ contains
   ! Refs: Norman et al. (Ag. Forest Met., 1995) -- citing Goudriaan (1977 manuscript "crop micrometeorology: a simulation study", Wageningen).
   windReductionFactor = windReductionParam * exposedVAI**twoThirds * (heightCanopyTopAboveSnow - heightCanopyBottomAboveSnow)**oneThird / leafDimension**oneThird
 
-  ! compute windspeed at the bottom of the canopy (m s-1)
+  ! compute windspeed at the bottom of the canopy relative to the snow depth (m s-1)
   referenceHeight      = max(heightCanopyBottomAboveSnow, z0Ground)
   windConvFactorBottom = exp(-windReductionFactor*(1._dp - (referenceHeight/heightCanopyTopAboveSnow)))
   windspdCanopyBottom  = windspdCanopyTop*windConvFactorBottom
@@ -2216,12 +2216,12 @@ contains
 
   ! compute the resistance between the surface and canopy air UNDER NEUTRAL CONDITIONS (s m-1)
   select case(ixWindProfile)
-   ! case 1: assume exponential profile extends from the surface roughness length to the displacement height plus vegetation roughness
+   ! case 1: assume exponential profile extends from the snow depth plus surface roughness length to the displacement height plus vegetation roughness
    case(exponential)
     tmp1 = exp(-windReductionFactor* referenceHeight/heightCanopyTopAboveSnow)
     tmp2 = exp(-windReductionFactor*(z0Canopy+zeroPlaneDisplacement)/heightCanopyTopAboveSnow)
     groundResistanceNeutral = ( heightCanopyTopAboveSnow*exp(windReductionFactor/heightCanopyTopAboveSnow) / (windReductionFactor*eddyDiffusCanopyTop) ) * (tmp1 - tmp2)   ! s m-1
-   ! case 2: logarithmic profile below the canopy
+   ! case 2: logarithmic profile from snow depth plus roughness height to bottom of the canopy
    case(logBelowCanopy)
     tmp1 = exp(-windReductionFactor* referenceHeight/heightCanopyTopAboveSnow)
     tmp2 = exp(-windReductionFactor*(z0Canopy+zeroPlaneDisplacement)/heightCanopyTopAboveSnow)

--- a/build/source/engine/vegNrgFlux.f90
+++ b/build/source/engine/vegNrgFlux.f90
@@ -2198,7 +2198,7 @@ contains
   windReductionFactor = windReductionParam * exposedVAI**twoThirds * (heightCanopyTopAboveSnow - heightCanopyBottomAboveSnow)**oneThird / leafDimension**oneThird
 
   ! compute windspeed at the bottom of the canopy (m s-1)
-  referenceHeight      = min(heightCanopyBottomAboveSnow, z0Ground)
+  referenceHeight      = max(heightCanopyBottomAboveSnow, z0Ground)
   windConvFactorBottom = exp(-windReductionFactor*(1._dp - referenceHeight/heightCanopyTop))
   windspdCanopyBottom  = windspdCanopyTop*windConvFactorBottom
 

--- a/build/source/engine/vegNrgFlux.f90
+++ b/build/source/engine/vegNrgFlux.f90
@@ -2225,7 +2225,7 @@ contains
    case(logBelowCanopy)
     tmp1 = exp(-windReductionFactor* referenceHeight/heightCanopyTopAboveSnow)
     tmp2 = exp(-windReductionFactor*(z0Canopy+zeroPlaneDisplacement)/heightCanopyTopAboveSnow)
-    if(referenceHeight > 0.0_dp)then  ! snow is above the bottom of the canopy -- just use the exponential profile
+    if(referenceHeight > z0Ground) then  ! snow is above the bottom of the canopy -- just use the exponential profile
      groundResistanceNeutral = ( heightCanopyTopAboveSnow*exp(windReductionFactor) / (windReductionFactor*eddyDiffusCanopyTop) ) * (tmp1 - tmp2)   ! s m-1
     else  ! snow is below the bottom of the canopy
      groundResistanceNeutral = ( heightCanopyTopAboveSnow*exp(windReductionFactor) / (windReductionFactor*eddyDiffusCanopyTop) ) * (tmp1 - tmp2) & ! s m-1


### PR DESCRIPTION
The `aeroResist` subroutine currently does not take the snow depth into account with calculating the wind speeds at the top and bottom of the canopy, as well as when calculating the ground resistance under neutral conditions.  This pull request adjusts those calculations and handles cases where the snow covers the canopy bottom as well as when snow covers the canopy completely.