### PR TITLE
Fix SUMMA version message as per issue 218

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -27,6 +27,7 @@ summa.exe
 *.layout
 gmon.out
 summa.exe.dSYM*
+summaversion.inc
 # makefile
 make.out
 Makefile-*

--- a/build/Makefile
+++ b/build/Makefile
@@ -273,7 +273,7 @@ DRIVER__EX = summa.exe
 
 # Define version number
 VERSIONFILE = $(DRIVER_DIR)/summaversion.inc
-VERSION = $(shell git tag | sed 's/v//')
+VERSION = $(shell git describe --tags --abbrev=0)
 BULTTIM = $(shell date)
 GITBRCH = $(shell git describe --long --all --always | sed -e's/heads\///')
 GITHASH = $(shell git rev-parse HEAD)

--- a/build/source/driver/summaversion.inc
+++ b/build/source/driver/summaversion.inc
@@ -1,4 +1,0 @@
-character(len=64), parameter     :: summaVersion = '1.0.0'
-character(len=64), parameter     :: buildTime = 'Sun Apr  9 09:49:57 MDT 2017'
-character(len=64), parameter     :: gitBranch = 'feature/checkChanges-0-ge264732'
-character(len=64), parameter     :: gitHash = 'e264732f654fc7d11d7e91e807da8cf1ba6bd3d9'


### PR DESCRIPTION
Fixes the version message. In addition: Since the `summaversion.inc` is remade during each make, it does not belong in the repo. 

Closes #218 