### PR TITLE
Make version number visible in docker version of summa

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,6 +4,7 @@ FROM ubuntu:zesty
 # install only the packages that are needed
 RUN apt-get update && \
     apt-get install -y --no-install-recommends \
+    ca-certificates \
     git \
     make \
     gfortran-6 \
@@ -21,8 +22,8 @@ ENV FC_ENV gfortran-6-docker
 WORKDIR /code
 ADD . /code
 
-# build summa
-RUN make -C build/ -f Makefile
+# fetch tags and build summa
+RUN git fetch --tags && make -C build/ -f Makefile
 
 # run summa when running the docker image
 WORKDIR bin

--- a/build/Makefile
+++ b/build/Makefile
@@ -273,7 +273,7 @@ DRIVER__EX = summa.exe
 
 # Define version number
 VERSIONFILE = $(DRIVER_DIR)/summaversion.inc
-VERSION = $(shell git describe --tags --abbrev=0)
+VERSION = $(shell git tag | tail -n 1)
 BULTTIM = $(shell date)
 GITBRCH = $(shell git describe --long --all --always | sed -e's/heads\///')
 GITHASH = $(shell git rev-parse HEAD)


### PR DESCRIPTION
In the Makefile I think that 
`VERSION = $(shell git describe --tags --abbrev=0)`
should work after a `git fetch --tags`, but for some reason is does not work from inside the docker file on hub.docker.com.
Replaced for now with
`VERSION = $(shell git tag | tail -n 1)`
which simply gives the latest tag.