### PR TITLE
Bug fix/single layer

### DIFF
--- a/build/source/engine/computJacob.f90
+++ b/build/source/engine/computJacob.f90
@@ -676,7 +676,7 @@ contains
      endif
    
      ! - include terms for baseflow
-     if(computeBaseflow)then
+     if(computeBaseflow .and. nSoilOnlyHyd==nSoil)then
       do pLayer=1,nSoil
        qState = ixSoilOnlyHyd(pLayer)  ! hydrology state index within the state subset
        aJac(watState,qState) = aJac(watState,qState) + (dt/mLayerDepth(jLayer))*dBaseflow_dMatric(iLayer,pLayer)

--- a/build/source/engine/opSplittin.f90
+++ b/build/source/engine/opSplittin.f90
@@ -812,9 +812,7 @@ contains
        endif
    
        ! define failure
-       failure = (failedMinimumStep .or. err<0 .or. ixSolution/=scalar)
-       if(iStateTypeSplit==nrgSplit .and. iDomainSplit==vegSplit .and. nDomainSplit==nDomains) failure=.false.
-       !failure = (failedMinimumStep .or. err<0)
+       failure = (failedMinimumStep .or. err<0)
        if(.not.failure) firstSuccess=.true.
 
        ! if failed, need to reset the flux counter


### PR DESCRIPTION
Minor bug fixes for the single layer solution:
1) The operator splitting code erroneously included the temporary code to force the single layer solution (used for testing). This temporary code has been removed.
2) The Jacobian calculations erroneously included the full matrix derivatives for baseflow in the single layer solution. The baseflow derivatives are now only used if all soil layers are included in the solver.