### PR TITLE
fix truncation of iteration increments for temperature

### DIFF
--- a/build/source/engine/summaSolve.f90
+++ b/build/source/engine/summaSolve.f90
@@ -1150,8 +1150,8 @@ contains
 
   ! ** limit temperature increment to zMaxTempIncrement
   if(any(abs(xInc(ixNrgOnly)) > zMaxTempIncrement))then
-   iMax       = maxloc( abs(xInc(ixNrgOnly)) )                            ! index of maximum temperature increment
-   xIncFactor = abs( zMaxTempIncrement/xInc(ixNrgOnly(iMax(1))) + epsT )  ! scaling factor for the iteration increment (-)
+   iMax       = maxloc( abs(xInc(ixNrgOnly)) )                     ! index of maximum temperature increment
+   xIncFactor = abs( zMaxTempIncrement/xInc(ixNrgOnly(iMax(1))) )  ! scaling factor for the iteration increment (-)
    xInc       = xIncFactor*xInc
   end if
 


### PR DESCRIPTION
There was a rare problem where there is a longwave flux imbalance. This occurred when the solver received unrealistic temperatures. The problem was actually an error in the truncation of iteration increments -- the small offset added to the iteration scale factor (epsT) caused iteration increments much larger than desired in cases where the initial iteration increment was very large. There is no need for this offset and it is removed.

This bug fix was tested for 100-year runs for the 11723 HRUs in the Columbia -- the runs completed without any errors.