### PR TITLE
Bug fix/duplicate meas height

### DIFF
--- a/build/source/engine/derivforce.f90
+++ b/build/source/engine/derivforce.f90
@@ -155,7 +155,7 @@ contains
  ! NOTE: could return an error or a warning
  ! NOTE: this does not need to be done every time step -- doing here for consistency with the snow adjustment
  if(mHeight < heightCanopyTop)then
-  adjMeasHeight = scalarSnowDepth+minMeasHeight  ! measurement height at least minMeasHeight above the canopy
+  adjMeasHeight = heightCanopyTop+minMeasHeight  ! measurement height at least minMeasHeight above the canopy
  else
   adjMeasHeight = mHeight
  endif

--- a/build/source/engine/derivforce.f90
+++ b/build/source/engine/derivforce.f90
@@ -118,6 +118,7 @@ contains
  mHeight                 => attr_data(iLookATTR%mHeight)                          , & ! latitude (degrees north)
  adjMeasHeight           => diag_data%var(iLookDIAG%scalarAdjMeasHeight)%dat(1)   , & ! adjusted measurement height (m)
  scalarSnowDepth         => prog_data%var(iLookPROG%scalarSnowDepth)%dat(1)       , & ! snow depth on the ground surface (m)
+ heightCanopyTop         => mpar_data%var(iLookPARAM%heightCanopyTop)%dat(1)      , & ! height of the top of the canopy layer (m)
  ! model forcing data
  SWRadAtm                => forc_data(iLookFORCE%SWRadAtm)                        , & ! downward shortwave radiation (W m-2)
  airtemp                 => forc_data(iLookFORCE%airtemp)                         , & ! air temperature at 2 meter height (K)
@@ -150,11 +151,18 @@ contains
   err=20; return
  end if
 
- ! compute the adjusted measurement height
- if(mHeight < scalarSnowDepth+minMeasHeight)then
-  adjMeasHeight = scalarSnowDepth+minMeasHeight  ! measurement height at least minMeasHeight above the surface
+ ! adjust the measurement height for the vegetation canopy
+ ! NOTE: could return an error or a warning
+ ! NOTE: this does not need to be done every time step -- doing here for consistency with the snow adjustment
+ if(mHeight < heightCanopyTop)then
+  adjMeasHeight = scalarSnowDepth+minMeasHeight  ! measurement height at least minMeasHeight above the canopy
  else
   adjMeasHeight = mHeight
+ endif
+
+ ! adjust the measurement height for snow depth
+ if(adjMeasHeight < scalarSnowDepth+minMeasHeight)then
+  adjMeasHeight = scalarSnowDepth+minMeasHeight  ! measurement height at least minMeasHeight above the snow surface
  endif
 
  ! compute the partial pressure of o2 and co2

--- a/build/source/engine/vegNrgFlux.f90
+++ b/build/source/engine/vegNrgFlux.f90
@@ -314,7 +314,6 @@ contains
  ! local (aerodynamic resistance)
  real(dp)                       :: scalarCanopyStabilityCorrection_old    ! stability correction for the canopy (-)
  real(dp)                       :: scalarGroundStabilityCorrection_old    ! stability correction for the ground surface (-)
- real(dp)                       :: uHeight                          ! height of windspeed measurement adjusted to be above vegetation canopy
 
  ! local (turbulent heat transfer)
  real(dp)                       :: z0Ground                         ! roughness length of the ground (ground below the canopy or non-vegetated surface) (m)
@@ -593,9 +592,6 @@ contains
  ! initialize error control
  err=0; message="vegNrgFlux/"
 
- ! set wind measurement height at distance above canopy
- uHeight = mHeight + heightCanopyTop
-
  ! initialize printflag
  printflag = .false.
 
@@ -807,7 +803,7 @@ contains
                    ix_windPrfile,                      & ! intent(in): choice of canopy wind profile
                    ix_astability,                      & ! intent(in): choice of stability function
                    ! input: above-canopy forcing data
-                   uHeight,                            & ! intent(in): measurement height (m)
+                   mHeight,                            & ! intent(in): measurement height (m)
                    airtemp,                            & ! intent(in): air temperature at some height above the surface (K)
                    windspd,                            & ! intent(in): wind speed at some height above the surface (m s-1)
                    ! input: canopy and ground temperature
@@ -1088,7 +1084,7 @@ contains
                      ix_windPrfile,                           & ! intent(in): choice of canopy wind profile
                      ix_astability,                           & ! intent(in): choice of stability function
                      ! input: above-canopy forcing data
-                     uHeight,                                 & ! intent(in): measurement height (m)
+                     mHeight,                                 & ! intent(in): measurement height (m)
                      airtemp,                                 & ! intent(in): air temperature at some height above the surface (K)
                      windspd,                                 & ! intent(in): wind speed at some height above the surface (m s-1)
                      ! input: temperature (canopy, ground, canopy air space)


### PR DESCRIPTION
Fixed temporary change where measurement height was always taken as above the top of the canopy.

Tested for the 100-year run over the Columbia.