### PR TITLE
Allow for no time zone info in time strings

### DIFF
--- a/build/source/engine/time_utils.f90
+++ b/build/source/engine/time_utils.f90
@@ -125,6 +125,7 @@ contains
 
  ! FIELD 3: Advance to the ih_tz:imin_tz string
  istart=nsub+1
+ if(istart>n) return  ! no more time info
 
  ! eat all the whitespace at the start of the string
  do while (refdate(istart:istart)==" ")


### PR DESCRIPTION
This pull request shortcuts parsing time zone information if none is available. It ensures backwards compatibility with older setups.