### PR TITLE
skip water balance checks when split to individual soil layers

### DIFF
--- a/build/source/engine/varSubstep.f90
+++ b/build/source/engine/varSubstep.f90
@@ -801,7 +801,7 @@ contains
 
   ! check mass balance for soil
   ! NOTE: fatal errors, though possible to recover using negative error codes
-  if(count(ixSoilOnlyHyd/=integerMissing)>0)then
+  if(count(ixSoilOnlyHyd/=integerMissing)==nSoil)then
    soilBalance1 = sum( (mLayerVolFracLiqTrial(nSnow+1:nLayers) + mLayerVolFracIceTrial(nSnow+1:nLayers) )*mLayerDepth(nSnow+1:nLayers) )
    vertFlux     = -(iLayerLiqFluxSoil(nSoil) - iLayerLiqFluxSoil(0))*dt  ! m s-1 --> m
    tranSink     = sum(mLayerTranspire)*dt                                ! m s-1 --> m


### PR DESCRIPTION
The code allows separate solutions for each soil layer when the solution is very slow. In these cases the water balance was *_erroneously_* calculated at the end of calculations for each soil layer. Code modified to only calculate the water balance when all soil layers are solved simultaneously.

There are other water balance checks later in the code, so this simplification should have limited impact.