### PR TITLE
Limit the amount of compaction to maintain volumetric fractions

### DIFF
--- a/build/source/engine/coupled_em.f90
+++ b/build/source/engine/coupled_em.f90
@@ -878,15 +878,8 @@ contains
                    prog_data%var(iLookPROG%mLayerVolFracIce)%dat(1:nSnow), & ! intent(inout):  volumetric fraction of ice after itertations (-)
                    ! output: error control
                    err,cmessage)                     ! intent(out): error control
-
-   ! update the volumetric fraction of liquid water
-   mLayerVolFracLiq(iSnow) = mLayerDepth(iSnow)*mLayerVolFracLiq(iSnow)*iden_water / (mLayerDepth(iSnow)*iden_water)
-   ! no snow
-   ! -------------------------------------------------------
-  end if  ! if snow layers exist
-  end associate sublime
-  ! Handle error outside of cycle
   if(err/=0)then; err=55; message=trim(message)//trim(cmessage); return; end if
+  end if  ! if snow layers exist
 
   ! update coordinate variables
   call calcHeight(&

--- a/build/source/engine/coupled_em.f90
+++ b/build/source/engine/coupled_em.f90
@@ -878,7 +878,7 @@ contains
                    prog_data%var(iLookPROG%mLayerVolFracIce)%dat(1:nSnow), & ! intent(inout):  volumetric fraction of ice after itertations (-)
                    ! output: error control
                    err,cmessage)                     ! intent(out): error control
-  if(err/=0)then; err=55; message=trim(message)//trim(cmessage); return; end if
+   if(err/=0)then; err=55; message=trim(message)//trim(cmessage); return; end if
   end if  ! if snow layers exist
 
   ! update coordinate variables

--- a/build/source/engine/coupled_em.f90
+++ b/build/source/engine/coupled_em.f90
@@ -854,6 +854,7 @@ contains
 
   end if  ! (if snow layers exist)
 
+  end associate sublime
 
   ! *** account for compaction and cavitation in the snowpack...
   ! ------------------------------------------------------------
@@ -878,28 +879,6 @@ contains
                    ! output: error control
                    err,cmessage)                     ! intent(out): error control
 
-   !----------------------------------------------
-   ! NOTE: this is done AFTER densification
-   ! try to remove ice from the top layer
-   iSnow=1
-   associate(&
-   ! model decisions
-   ix_snowLayers    => model_decisions(iLookDECISIONS%snowLayers)%iDecision, & ! decision for snow combination
-   ! model parameters (control the depth of snow layers)
-   zmin             => mpar_data%var(iLookPARAM%zmin)%dat(1),                & ! minimum layer depth (m)
-   zminLayer1       => mpar_data%var(iLookPARAM%zminLayer1)%dat(1)) ! ,          & ! minimum layer depth for the 1st (top) layer (m)
-   ! check that we did not remove the entire layer
-   if(mLayerDepth(iSnow) < max(zmin, zminLayer1)) then
-    stepFailure  = .true.
-    doLayerMerge = .true.
-    dt_sub      = max(dtSave/2._dp, minstep)
-    cycle substeps
-   else
-    stepFailure  = .false.
-    doLayerMerge = .false.
-   endif
-   end associate
-   ! end associate statement
    ! update the volumetric fraction of liquid water
    mLayerVolFracLiq(iSnow) = mLayerDepth(iSnow)*mLayerVolFracLiq(iSnow)*iden_water / (mLayerDepth(iSnow)*iden_water)
    ! no snow

--- a/build/source/engine/coupled_em.f90
+++ b/build/source/engine/coupled_em.f90
@@ -882,9 +882,14 @@ contains
    ! NOTE: this is done AFTER densification
    ! try to remove ice from the top layer
    iSnow=1
-
+   associate(&
+   ! model decisions
+   ix_snowLayers    => model_decisions(iLookDECISIONS%snowLayers)%iDecision, & ! decision for snow combination
+   ! model parameters (control the depth of snow layers)
+   zmin             => mpar_data%var(iLookPARAM%zmin)%dat(1),                & ! minimum layer depth (m)
+   zminLayer1       => mpar_data%var(iLookPARAM%zminLayer1)%dat(1)) ! ,          & ! minimum layer depth for the 1st (top) layer (m)
    ! check that we did not remove the entire layer
-   if(mLayerDepth(iSnow) < verySmall)then
+   if(mLayerDepth(iSnow) < max(zmin, zminLayer1)) then
     stepFailure  = .true.
     doLayerMerge = .true.
     dt_sub      = max(dtSave/2._dp, minstep)
@@ -893,7 +898,8 @@ contains
     stepFailure  = .false.
     doLayerMerge = .false.
    endif
-
+   end associate
+   ! end associate statement
    ! update the volumetric fraction of liquid water
    mLayerVolFracLiq(iSnow) = mLayerDepth(iSnow)*mLayerVolFracLiq(iSnow)*iden_water / (mLayerDepth(iSnow)*iden_water)
    ! no snow

--- a/build/source/engine/snwCompact.f90
+++ b/build/source/engine/snwCompact.f90
@@ -169,7 +169,7 @@ contains
 
   ! check that depth is reasonable
   if(mLayerDepth(iSnow) < 0._dp)then
-   write(*,'(a,1x,i4,1x,10(f12.5,1x))') 'iSnow, dt, density, massIceOld, massLiqOld = ', iSnow, dt, mLayerVolFracIceNew(iSnow)*iden_ice, massIceOld, massLiqOld
+   write(*,'(a,1x,i4,1x,10(f12.5,1x))') 'iSnow, dt, density,massIceOld, massLiqOld = ', iSnow, dt, mLayerVolFracIceNew(iSnow)*iden_ice, massIceOld, massLiqOld
    write(*,'(a,1x,i4,1x,10(f12.5,1x))') 'iSnow, mLayerDepth(iSnow), scalarDepthNew, mLayerVolFracIceNew(iSnow), mLayerMeltFreeze(iSnow), CR_grainGrowth*dt, CR_ovrvdnPress*dt = ', &
                                          iSnow, mLayerDepth(iSnow), scalarDepthNew, mLayerVolFracIceNew(iSnow), mLayerMeltFreeze(iSnow), CR_grainGrowth*dt, CR_ovrvdnPress*dt
   endif
@@ -194,7 +194,7 @@ contains
 
  ! check for low/high snow density
  if(any(mLayerVolFracIceNew(1:nSnow)*iden_ice + mLayerVolFracLiqNew(1:nSnow)*iden_water + mLayerVolFracAirNew(1:nSnow)*iden_air < minLayerDensity) .or. &
-    any(mLayerVolFracIceNew(1:nSnow) > 1._dp))then
+    any(mLayerVolFracIceNew(1:nSnow) + mLayerVolFracLiqNew(1:nSnow) + mLayerVolFracAirNew(1:nSnow) > 1._dp))then
   do iSnow=1,nSnow
    write(*,*) 'iSnow, volFracIce, density = ', iSnow, mLayerVolFracIceNew(iSnow),  mLayerVolFracIceNew(iSnow)*iden_ice
   end do

--- a/build/source/engine/snwCompact.f90
+++ b/build/source/engine/snwCompact.f90
@@ -164,15 +164,9 @@ contains
   ! can occur given the masses of ice and liquid in the layer
   scalarDepthNew = scalarDepthNew/(1._dp + CR_metamorph*dt)
   scalarDepthMin = (massIceOld / iden_ice) + (massLiqOld / iden_water)
-  mLayerDepth(iSnow) = scalarDepthNew
+  mLayerDepth(iSnow) = max(scalarDepthMin, scalarDepthNew)
   mLayerVolFracIceNew(iSnow) = massIceOld/(mLayerDepth(iSnow)*iden_ice)
   mLayerVolFracLiqNew(iSnow) = massLiqOld/(mLayerDepth(iSnow)*iden_water)
-  if (scalarDepthMin > scalarDepthNew) then
-    scalarDepthNew = scalarDepthMin
-    mLayerDepth(iSnow) = scalarDepthNew
-    mLayerVolFracIceNew(iSnow) = massIceOld/(mLayerDepth(iSnow)*iden_ice)
-    mLayerVolFracLiqNew(iSnow) = massLiqOld/(mLayerDepth(iSnow)*iden_water)
-  end if
 
   ! check that depth is reasonable
   if(mLayerDepth(iSnow) < 0._dp)then

--- a/build/source/engine/snwCompact.f90
+++ b/build/source/engine/snwCompact.f90
@@ -156,7 +156,6 @@ contains
   else
    scalarDepthNew = mLayerDepth(iSnow)
   end if
-
   ! compute the total compaction rate associated with metamorphism
   CR_metamorph = CR_grainGrowth + CR_ovrvdnPress
   ! update depth due to metamorphism (implicit solution)
@@ -165,8 +164,6 @@ contains
   scalarDepthNew = scalarDepthNew/(1._dp + CR_metamorph*dt)
   scalarDepthMin = (massIceOld / iden_ice) + (massLiqOld / iden_water)
   mLayerDepth(iSnow) = max(scalarDepthMin, scalarDepthNew)
-  mLayerVolFracIceNew(iSnow) = massIceOld/(mLayerDepth(iSnow)*iden_ice)
-  mLayerVolFracLiqNew(iSnow) = massLiqOld/(mLayerDepth(iSnow)*iden_water)
 
   ! check that depth is reasonable
   if(mLayerDepth(iSnow) < 0._dp)then
@@ -176,6 +173,8 @@ contains
   endif
 
   ! update volumetric ice and liquid water content
+  mLayerVolFracIceNew(iSnow) = massIceOld/(mLayerDepth(iSnow)*iden_ice)
+  mLayerVolFracLiqNew(iSnow) = massLiqOld/(mLayerDepth(iSnow)*iden_water)
   !write(*,'(a,1x,i4,1x,f9.3)') 'after compact: iSnow, density = ', iSnow, mLayerVolFracIceNew(iSnow)*iden_ice
   !if(mLayerMeltFreeze(iSnow) > 20._dp) pause 'meaningful melt'
 
@@ -194,7 +193,7 @@ contains
  if(any(mLayerVolFracIceNew(1:nSnow)*iden_ice < minLayerDensity) .or. &
     any(mLayerVolFracIceNew(1:nSnow) > 1._dp))then
   do iSnow=1,nSnow
-   write(*,*) 'iSnow, density = ', iSnow, mLayerVolFracIceNew(iSnow),  mLayerVolFracIceNew(iSnow)*iden_ice
+   write(*,*) 'iSnow, volFracIce, density = ', iSnow, mLayerVolFracIceNew(iSnow),  mLayerVolFracIceNew(iSnow)*iden_ice
   end do
   message=trim(message)//'unreasonable value for snow density'
   err=20; return


### PR DESCRIPTION
This attempts to fix #363 and has two portions, but still has some issues. The first is in `snwCompact.f90` and works by computing the maximum allowable amount of snow compaction to ensure that the volumetric fractions of ice and liquid sum to 1. Then, if the computed compaction is greater than this, the maximum is substituted. The second is in `coupled_em.f90` to address a follow-on issue. When the amount of compaction is great enough to run into this issue it is possible for the snow layering to drop below the threshold-minimum level. I have added a check to see if we need to do any layer merging after the compaction routine to avoid this issue.

There is still one outstanding problem with this pull request that I would like feedback on, perhaps @martynpclark and @bartnijssen have ideas? 

There is still a case where the snow density can be too low, especially when there are very small volumetric fractions of ice in a layer and the layer depth is small. It seems the fix for this should be to add the layer merge call, but the condition for applying a layer merge is much smaller (`verySmall = 1e-6`) than the minimum layer depth in many cases. Because of this, the low density error can still occur. Relaxing the constraint on doing layer merges to ensure that tiny layers aren't leftover here ends up breaking mass balance.