### PR TITLE
Remove some dead code

### DIFF
--- a/build/source/engine/varSubstep.f90
+++ b/build/source/engine/varSubstep.f90
@@ -350,19 +350,8 @@ contains
 
   ! reduce step based on failure
   if(failedSubstep)then
-
-   ! solver failure
-   if(err<0)then
     err=0; message='varSubstep/'  ! recover from failed convergence
     dtMultiplier  = 0.5_dp        ! system failure: step halving
-
-   ! nothing else defined
-   else
-    message=trim(message)//'unknown failure'
-    err=20; return
-   endif
-
-  ! successful step
   else
 
    ! ** implicit Euler: adjust step length based on iteration count


### PR DESCRIPTION
This just removes a little bit of code that is unreachable. In this if statement the first condition, `failedSubstep` is already defined above as `failedSubstep = (err<0)`.