### PR TITLE
Increase maximum path length.

### DIFF
--- a/build/source/hookup/summaFileManager.f90
+++ b/build/source/hookup/summaFileManager.f90
@@ -26,7 +26,7 @@ use nrtype
 implicit none
 public
 ! summa-wide pathlength
-integer(i4b),parameter::summaPathLen=256
+integer(i4b),parameter::summaPathLen=4096
 ! defines the path for data files (and default values)
 CHARACTER(LEN=summaPathLen)  :: SETNGS_PATH='settings/'         ! SETNGS_PATH
 CHARACTER(LEN=summaPathLen)  :: INPUT_PATH ='input/default/'    ! INPUT_PATH


### PR DESCRIPTION
The previous path length defined in the file manager reading code was too short for some of my ensemble runs with pysumma so I have increased it. The overall maximum path lengths for various operating systems seems to depend on the file systems they are installed in, but here are some rules of thumb:

Windows: 260 characters (newer versions of Windows 10 allow for modification of this limit)
MacOS: 1024 characters on HFS, unlimited on HFSplus
Linux: 4096 characters (defined in the kernel)

With this in mind I feel we should just expand it to 4096 (the biggest concrete number I could find), and then just let the OS be the real arbiter.