### PR TITLE
1) write hruId to all output files (using same function with hru)

### DIFF
--- a/build/source/driver/summa_defineOutput.f90
+++ b/build/source/driver/summa_defineOutput.f90
@@ -18,12 +18,11 @@
 ! You should have received a copy of the GNU General Public License
 ! along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-module summa_defineOutput
-! used to define model output files
+module summa_defineOutput                     ! used to define model output files
 
 ! access missing values
-USE globalData,only:integerMissing   ! missing integer
-USE globalData,only:realMissing      ! missing double precision number
+USE globalData,only:integerMissing            ! missing integer
+USE globalData,only:realMissing               ! missing double precision number
 
 ! named variables to define new output files
 USE globalData, only: noNewFiles              ! no new output files
@@ -32,7 +31,7 @@ USE globalData, only: newFileEveryOct1        ! create a new file on Oct 1 every
 ! metadata structures
 USE globalData,only:attr_meta                 ! attributes metadata structure
 USE globalData,only:type_meta                 ! veg/soil type metadata structure
-USE globalData,only:id_meta                   ! veg/soil type metadata structure
+USE globalData,only:id_meta                   ! hru and gru Id metadata structure
 USE globalData,only:mpar_meta                 ! local parameter metadata structure
 USE globalData,only:bpar_meta                 ! basin parameter metadata structure
 
@@ -101,11 +100,13 @@ contains
  ! *** define the name of the model output file
  ! *****************************************************************************
 
- ! define name of output file : spinup
+ ! define full name of output file 
  if(modelTimeStep==1)then
   select case(newOutputFile)
-   case(noNewFiles);       fileout = trim(OUTPUT_PATH)//trim(OUTPUT_PREFIX)//'output'//trim(output_fileSuffix)
-   case(newFileEveryOct1); fileout = trim(OUTPUT_PATH)//trim(OUTPUT_PREFIX)//'spinup'//trim(output_fileSuffix)
+   !case(noNewFiles);       fileout = trim(OUTPUT_PATH)//trim(OUTPUT_PREFIX)//'output'//trim(output_fileSuffix)
+   case(noNewFiles);       fileout = trim(OUTPUT_PATH)//trim(OUTPUT_PREFIX)//trim(output_fileSuffix)
+   !case(newFileEveryOct1); fileout = trim(OUTPUT_PATH)//trim(OUTPUT_PREFIX)//'spinup'//trim(output_fileSuffix)
+   case(newFileEveryOct1); fileout = trim(OUTPUT_PATH)//trim(OUTPUT_PREFIX)//trim(output_fileSuffix)
    case default; err=20; message=trim(message)//'unable to identify the option to define new output files'; return
   end select
 
@@ -133,7 +134,7 @@ contains
     select case(trim(structInfo(iStruct)%structName))
      case('attr'); call writeParm(gru_struc(iGRU)%hruInfo(iHRU)%hru_ix,attrStruct%gru(iGRU)%hru(iHRU),attr_meta,err,cmessage)
      case('type'); call writeParm(gru_struc(iGRU)%hruInfo(iHRU)%hru_ix,typeStruct%gru(iGRU)%hru(iHRU),type_meta,err,cmessage)
-     case('id');   call writeParm(gru_struc(iGRU)%hruInfo(iHRU)%hru_ix,  idStruct%gru(iGRU)%hru(iHRU),  id_meta,err,cmessage)
+     !case('id');   call writeParm(gru_struc(iGRU)%hruInfo(iHRU)%hru_ix,  idStruct%gru(iGRU)%hru(iHRU),  id_meta,err,cmessage)
      case('mpar'); call writeParm(gru_struc(iGRU)%hruInfo(iHRU)%hru_ix,mparStruct%gru(iGRU)%hru(iHRU),mpar_meta,err,cmessage)
     end select
     if(err/=0)then; message=trim(message)//trim(cmessage)//'['//trim(structInfo(iStruct)%structName)//']'; return; endif
@@ -151,5 +152,3 @@ contains
 
  end subroutine summa_defineOutputFiles
 end module summa_defineOutput
-
-

--- a/build/source/driver/summa_init.f90
+++ b/build/source/driver/summa_init.f90
@@ -306,8 +306,9 @@ contains
  ! *** define the suffix for the model output file
  ! *****************************************************************************
 
- ! set up the output file names as: OUTPUT_PREFIX_spinup|waterYear_output_fileSuffix_startGRU-endGRU_outfreq.nc or OUTPUT_PREFIX_spinup|waterYear_output_fileSuffix_HRU_outfreq.nc;
- if (OUTPUT_PREFIX(len_trim(OUTPUT_PREFIX):len_trim(OUTPUT_PREFIX)) /= '_') OUTPUT_PREFIX=trim(OUTPUT_PREFIX)//'_' ! separate OUTPUT_PREFIX from others by underscore
+ !x set up the output file names as: OUTPUT_PREFIX_spinup|waterYear_output_fileSuffix_startGRU-endGRU_outfreq.nc or OUTPUT_PREFIX_spinup|waterYear_output_fileSuffix_HRU_outfreq.nc;
+ ! set up the output file names as: OUTPUT_PREFIX'_'output_fileSuffix'_'startGRU-endGRU_outfreq.nc or OUTPUT_PREFIX'_'output_fileSuffix'_'HRU_outfreq.nc;
+ !if (OUTPUT_PREFIX(len_trim(OUTPUT_PREFIX):len_trim(OUTPUT_PREFIX)) /= '_') OUTPUT_PREFIX=trim(OUTPUT_PREFIX)//'_' ! separate OUTPUT_PREFIX from others by underscore (handled later)
  if (output_fileSuffix(1:1) /= '_') output_fileSuffix='_'//trim(output_fileSuffix)                                 ! separate output_fileSuffix from others by underscores
  if (output_fileSuffix(len_trim(output_fileSuffix):len_trim(output_fileSuffix)) == '_') output_fileSuffix(len_trim(output_fileSuffix):len_trim(output_fileSuffix)) = ' '
  select case (iRunMode)

--- a/build/source/driver/summa_util.f90
+++ b/build/source/driver/summa_util.f90
@@ -211,11 +211,11 @@ contains
      err=1; return
     endif
     select case (trim(argString(iArgument+1)))
-     case ('t' , 'timestep');  ixProgress = ixProgress_it  ! default
-     case ('h' , 'hour');  ixProgress = ixProgress_ih
-     case ('d' , 'day');   ixProgress = ixProgress_id
-     case ('m' , 'month'); ixProgress = ixProgress_im
-     case ('n' , 'never'); ixProgress = ixProgress_never
+     case ('t' , 'timestep');  ixProgress = ixProgress_it
+     case ('h' , 'hour');      ixProgress = ixProgress_ih
+     case ('d' , 'day');       ixProgress = ixProgress_id  ! default
+     case ('m' , 'month');     ixProgress = ixProgress_im
+     case ('n' , 'never');     ixProgress = ixProgress_never
      case default
       message='unknown frequency to print progress'
       err=1; return

--- a/build/source/dshare/get_ixname.f90
+++ b/build/source/dshare/get_ixname.f90
@@ -953,7 +953,7 @@ contains
 
  ! *******************************************************************************************************************
  ! public subroutine get_ixUnknown: get the index of the named variable type from ANY structure, as well as the
- ! structrue that it was found in
+ ! structure that it was found in
  ! *******************************************************************************************************************
  subroutine get_ixUnknown(varName,typeName,vDex,err,message)
  USE nrtype
@@ -962,7 +962,7 @@ contains
 
  ! dummies
  character(*),intent(in)  :: varName   ! variable name
- character(*),intent(out) :: typeName  ! variable type name
+ character(*),intent(out) :: typeName  ! variable type (structure) name
  integer(i4b),intent(out) :: vDex      ! variable index in structure
  integer(i4b),intent(out) :: err       ! error code
  character(*),intent(out) :: message   ! error message
@@ -982,7 +982,7 @@ contains
    case ('forc' ); vDex = get_ixForce(trim(varName))
    case ('attr' ); vDex = get_ixAttr(trim(varName))
    case ('type' ); vDex = get_ixType(trim(varName))
-   case ('id' );   vDex = get_ixId(trim(varName))
+   case ('id'   ); vDex = get_ixId(trim(varName))
    case ('mpar' ); vDex = get_ixParam(trim(varName))
    case ('indx' ); vDex = get_ixIndex(trim(varName))
    case ('prog' ); vDex = get_ixProg(trim(varName))

--- a/build/source/dshare/globalData.f90
+++ b/build/source/dshare/globalData.f90
@@ -321,7 +321,7 @@ MODULE globalData
  type(var_i),save,public                     :: oldTime                 ! time for the previous model time step
 
  ! output file information
- logical(lgt),dimension(maxvarFreq),save,public :: outFreq              ! true if the outut frequency is desired
+ logical(lgt),dimension(maxvarFreq),save,public :: outFreq              ! true if the output frequency is desired
  integer(i4b),dimension(maxvarFreq),save,public :: ncid                 ! netcdf output file id
 
 END MODULE globalData

--- a/build/source/dshare/outpt_stat.f90
+++ b/build/source/dshare/outpt_stat.f90
@@ -95,7 +95,7 @@ contains
 
 
  ! ***********************************************************************************
- ! Private subroutine calc_stats is a generic fucntion to deal with any variable type.
+ ! Private subroutine calc_stats is a generic function to deal with any variable type.
  ! Called from compile_stats
  ! ***********************************************************************************
  subroutine calc_stats(meta,stat,tdata,resetStats,finalizeStats,statCounter,err,message)
@@ -139,7 +139,7 @@ contains
  ! ---------------------------------------------
  do iFreq=1,maxVarFreq                              ! loop through output statistics
   if(resetStats(iFreq))then                         ! flag to reset statistics
-   if(meta%statIndex(iFreq)==integerMissing) cycle  ! don't bother if output frequency is not desired for a given variab;e
+   if(meta%statIndex(iFreq)==integerMissing) cycle  ! don't bother if output frequency is not desired for a given variable
    if(meta%varType/=iLookVarType%outstat) cycle     ! only calculate stats for scalars
    select case(meta%statIndex(iFreq))               ! act depending on the statistic
     ! -------------------------------------------------------------------------------------
@@ -196,7 +196,7 @@ contains
  end do ! looping through output frequencies
 
  ! ---------------------------------------------
- ! finalize statistics at end of frequenncy period
+ ! finalize statistics at end of frequency period
  ! ---------------------------------------------
  do iFreq=1,maxVarFreq                                ! loop through output statistics
   if(finalizeStats(iFreq))then


### PR DESCRIPTION
2) avoid opening and default-writing timestep variables
3) remove pre-loaded outputfile suffixes
4) miscellaneous typo fixes