### PR TITLE
Add ability to have minutes as reference timestep

### DIFF
--- a/build/source/engine/read_force.f90
+++ b/build/source/engine/read_force.f90
@@ -391,6 +391,7 @@ contains
  ! get the time multiplier needed to convert time to units of days
  select case( trim( refTimeString(1:index(refTimeString,' ')) ) )
   case('seconds'); forcFileInfo(iFile)%convTime2Days=86400._dp
+  case('minutes'); forcFileInfo(iFile)%convTime2Days=1440._dp
   case('hours');   forcFileInfo(iFile)%convTime2Days=24._dp
   case('days');    forcFileInfo(iFile)%convTime2Days=1._dp
   case default;    message=trim(message)//'unable to identify time units'; err=20; return

--- a/docs/input_output/SUMMA_input.md
+++ b/docs/input_output/SUMMA_input.md
@@ -164,7 +164,7 @@ spechum  | time, hru | double | g g-1 | Specific humidity at the [measurement he
 
 Notes about forcing file format:
 
-* <a id="forcing_file_time_units">Forcing timestep units</a>: The user can specify the time units as `<units> since <reference time>`, where `<units>` is one of `seconds`, `hours`, or `days` and `<reference time>` is specified as `YYYY-MM-DD hh:mm`.
+* <a id="forcing_file_time_units">Forcing timestep units</a>: The user can specify the time units as `<units> since <reference time>`, where `<units>` is one of `seconds`, `minutes`, `hours`, or `days` and `<reference time>` is specified as `YYYY-MM-DD hh:mm`.
 
 * <a id="forcing_file_time_stamp">Forcing time stamp</a>: SUMMA forcing time stamps are period-ending and the forcing information reflects average conditions over the time interval of length `data_step` preceding the time stamp.
 


### PR DESCRIPTION
This just allows `minutes` to be the reference time units from the given reference time for forcing data.