### PR TITLE
Specify precision in ACOS calls

### DIFF
--- a/build/source/engine/sunGeomtry.f90
+++ b/build/source/engine/sunGeomtry.f90
@@ -99,7 +99,7 @@ contains
  ! In such cases AUX > 1 or AUX < -1. Fix AUX at (-)1 in those cases, to fix sunrise at 00.00 or 24.00 of the current day (instead of some time before/after the current day)
  AUX=-TAN(LAT1)*TAN(D)
  IF(abs(AUX) > 1.) THEN
-  TD=ACOS(SIGN(1., AUX))
+  TD=ACOS(SIGN(1._dp, AUX))
  ELSE
   TD=ACOS(AUX)
  END IF
@@ -140,7 +140,7 @@ contains
   ! In such cases AUX > 1 or AUX < -1. Fix AUX at (-)1 in those cases
   AUX=-TAN(LAT1)*TAN(D)
   IF(abs(AUX) > 1.) THEN
-   TD=ACOS(SIGN(1., AUX))
+   TD=ACOS(SIGN(1._dp, AUX))
   ELSE
    TD=ACOS(AUX)
   END IF


### PR DESCRIPTION
Minor fix that enables compilation on some platforms (like Cheyenne)