### PR TITLE
Added suggestion for documentation branch naming to docs/SUMMA_git_workglow.md

### DIFF
--- a/docs/development/SUMMA_git_workflow.md
+++ b/docs/development/SUMMA_git_workflow.md
@@ -33,6 +33,7 @@ Although anyone could create these branches, they are designed for the preparati
 ## Naming Conventions
  * Master branch – master
  * Develop branch – develop
+ * Documentation branch - docs/{doc_change_name}
  * Feature branch – feature/{feature_name}
  * Hotfix branch – hotfix/{hotfix_name}
  * Release branch – release/{release_name}


### PR DESCRIPTION
Current naming conventions for Github branches do not have a clear choice for documentation updated. Suggested to use:
`docs/{doc_change_name}`