### PR TITLE
Updated read_force.f90 to correctly report netcdf reading error

### DIFF
--- a/build/source/engine/read_force.f90
+++ b/build/source/engine/read_force.f90
@@ -486,6 +486,10 @@ contains
   ! get index in forcing structure
   iVar = forcFileInfo(iFile)%var_ix(iNC)
   checkForce(iVar) = .true.
+  
+  ! get variable name for error reporting
+  err=nf90_inquire_variable(ncid,iNC,name=varName)
+  if(err/=nf90_noerr)then; message=trim(message)//'problem reading forcing variable name from netCDF: '//trim(nf90_strerror(err)); return; endif
 
   ! read forcing data for all HRUs
   if(simultaneousRead)then


### PR DESCRIPTION
read_force.f90 can print error message if reading of data from a netcdf file fails. The error messages in subroutinereadForcingData()
```
! read forcing data for all HRUs
  if(simultaneousRead)then
   err=nf90_get_var(ncid,forcFileInfo(iFile)%data_id(ivar),dataVec,start=(/ixHRUfile_min,iRead/),count=(/nHRUlocal,1/))
   if(err/=nf90_noerr)then; message=trim(message)//'problem reading forcing data: '//trim(varname)//'/'//trim(nf90_strerror(err)); return; endif
  endif
```
and
```
! read forcing data for a single HRU
    if(.not.simultaneousRead)then
     err=nf90_get_var(ncid,forcFileInfo(iFile)%data_id(ivar),dataVal,start=(/iHRU_global,iRead/))
     if(err/=nf90_noerr)then; message=trim(message)//'problem reading forcing data: '//trim(varName)//'/'//trim(nf90_strerror(err)); return; endif
    endif
```
needs variable `varName`. This variable is undefined in the current code and thus this error message attempts to print an undefined string. This fix gets the varName before the reading error can occur and this ensures a readable error message.

Error without fix:
```
number of time steps =          65
Skipping over LUTYPE = USGS
Skipping over SLTYPE = STAS
Skipping over SLTYPE = STAS-RUC


WARNING: summa_readForcing/readForcingData/problem reading forcing data:                                                                                                                                                                                         	       ‡       °        

 (can keep going, but stopping anyway)

```

Error after fix:
```
number of time steps =          65
Skipping over LUTYPE = USGS
Skipping over SLTYPE = STAS
Skipping over SLTYPE = STAS-RUC


WARNING: summa_readForcing/readForcingData/problem reading forcing data: pptrate/NetCDF: Start+count exceeds dimension boundgetFirstTimestep/

 (can keep going, but stopping anyway)
```