### PR TITLE
avoid very small stability values

### DIFF
--- a/build/source/engine/vegNrgFlux.f90
+++ b/build/source/engine/vegNrgFlux.f90
@@ -3140,6 +3140,7 @@ contains
  integer(i4b),intent(out)      :: err                    ! error code
  character(*),intent(out)      :: message                ! error message
  ! local
+ real(dp), parameter           :: verySmall=1.e-10_dp    ! a very small number (avoid stability of zero)
  real(dp)                      :: dRiBulk_dAirTemp       ! derivative in the bulk Richardson number w.r.t. air temperature (K-1)
  real(dp)                      :: dRiBulk_dSfcTemp       ! derivative in the bulk Richardson number w.r.t. surface temperature (K-1)
  real(dp)                      :: bPrime                 ! scaled "b" parameter for stability calculations in Louis (1979)
@@ -3188,11 +3189,11 @@ contains
   case(standard)
    ! compute surface-atmosphere exchange coefficient (-)
    if(RiBulk <  critRichNumber) stabilityCorrection = (1._dp - 5._dp*RiBulk)**2._dp
-   if(RiBulk >= critRichNumber) stabilityCorrection = epsilon(stabilityCorrection)
+   if(RiBulk >= critRichNumber) stabilityCorrection = verySmall
    ! compute derivative in surface-atmosphere exchange coefficient w.r.t. temperature (K-1)
    if(computeDerivative)then
     if(RiBulk <  critRichNumber) dStabilityCorrection_dRich = (-5._dp) * 2._dp*(1._dp - 5._dp*RiBulk)
-    if(RiBulk >= critRichNumber) dStabilityCorrection_dRich = 0._dp
+    if(RiBulk >= critRichNumber) dStabilityCorrection_dRich = verySmall
    end if
 
   ! (Louis 1979)


### PR DESCRIPTION
The "standard" option for the stability correction is zero above the critical Richardson number. This provides an angle discontinuity -- close to the critical Richardson number values. The other stability corrections are more smooth.

To reduce numerical problems, the stability correction for the "standard" option sets stability to epsilon (~10^-16) if the bulk Richardson number is higher than the critical Richardson number. This still causes convergence problems. Suggest a minor modification to set the stability correction to 10^-10 if the Richardson number is above the critical value.