### PR TITLE
Bugfix/restart split domain

### DIFF
--- a/build/source/netcdf/read_icond.f90
+++ b/build/source/netcdf/read_icond.f90
@@ -276,7 +276,6 @@ contains
 
   ! get data
   err = nf90_get_var(ncID,ncVarID,varData); call netcdf_err(err,message)
-  write(*,*) shape(varData), shape(gru_struc), ixFile
   if(err/=0)then; message=trim(message)//': problem getting the data for variable '//trim(prog_meta(iVar)%varName); return; endif
 
   ! store data in prognostics structure
@@ -294,9 +293,7 @@ contains
 
     ! get the index in the file: single HRU
     if(restartFileType==singleHRU)then
-     !  ixFile = 1  ! use for single HRU restart file
-     ixFile = startGRU
-
+     ixFile = 1  ! use for single HRU restart file
     ! get the index in the file: multi HRU
     else
      ixFile = startGRU + iHRU_local - 1
@@ -451,7 +448,7 @@ contains
     do iGRU = 1,nGRU
 
      ! put the data into data structures
-     bvarData%gru(iGRU)%var(iVar)%dat(1:nTDH) = varData(iGRU,1:nTDH)
+     bvarData%gru(iGRU)%var(iVar)%dat(1:nTDH) = varData((iGRU+startGRU-1),1:nTDH)
      ! check whether the first values is set to nf90_fill_double
      if(any(abs(bvarData%gru(iGRU)%var(iVar)%dat(1:nTDH) - nf90_fill_double) < epsilon(varData)))then; err=20; endif
      if(err==20)then; message=trim(message)//"data set to the fill value (name='"//trim(bvar_meta(iVar)%varName)//"')"; return; endif

--- a/build/source/netcdf/read_icond.f90
+++ b/build/source/netcdf/read_icond.f90
@@ -42,6 +42,7 @@ contains
  USE nrtype
  USE var_lookup,only:iLookIndex                        ! variable lookup structure
  USE globalData,only:gru_struc                         ! gru-hru mapping structures
+ USE globalData,only:startGRU                          ! index of first gru for parallel runs
  USE netcdf_util_module,only:nc_file_close             ! close netcdf file
  USE netcdf_util_module,only:nc_file_open              ! close netcdf file
  USE netcdf_util_module,only:netcdf_err                ! netcdf error handling
@@ -159,6 +160,7 @@ contains
  USE globalData,only:prog_meta                          ! metadata for prognostic variables
  USE globalData,only:bvar_meta                          ! metadata for basin (GRU) variables
  USE globalData,only:gru_struc                          ! gru-hru mapping structures
+ USE globalData,only:startGRU                          ! index of first gru for parallel runs
  USE globaldata,only:iname_soil,iname_snow              ! named variables to describe the type of layer
  USE netcdf_util_module,only:nc_file_open               ! open netcdf file
  USE netcdf_util_module,only:nc_file_close              ! close netcdf file
@@ -213,7 +215,7 @@ contains
  character(len=32),parameter            :: midTotoDimName='midToto'  ! dimension name for layered varaiables
  character(len=32),parameter            :: ifcTotoDimName='ifcToto'  ! dimension name for layered varaiables
  character(len=32),parameter            :: tdhDimName    ='tdh'      ! dimension name for time-delay basin variables
- 
+
  ! --------------------------------------------------------------------------------------------------------
 
  ! Start procedure here
@@ -229,7 +231,7 @@ contains
  ! get number of HRUs in file
  err = nf90_inq_dimid(ncID,"hru",dimID);               if(err/=nf90_noerr)then; message=trim(message)//'problem finding hru dimension/'//trim(nf90_strerror(err)); return; end if
  err = nf90_inquire_dimension(ncID,dimID,len=fileHRU); if(err/=nf90_noerr)then; message=trim(message)//'problem reading hru dimension/'//trim(nf90_strerror(err)); return; end if
- 
+
  ! loop through prognostic variables
  do iVar = 1,size(prog_meta)
 
@@ -274,6 +276,7 @@ contains
 
   ! get data
   err = nf90_get_var(ncID,ncVarID,varData); call netcdf_err(err,message)
+  write(*,*) shape(varData), shape(gru_struc), ixFile
   if(err/=0)then; message=trim(message)//': problem getting the data for variable '//trim(prog_meta(iVar)%varName); return; endif
 
   ! store data in prognostics structure
@@ -283,7 +286,7 @@ contains
 
     iHRU_global = gru_struc(iGRU)%hruInfo(iHRU)%hru_nc
     iHRU_local = (iHRU_global - ixHRUfile_min) + 1
-    
+
     ! get the number of layers
     nSnow = gru_struc(iGRU)%hruInfo(iHRU)%nSnow
     nSoil = gru_struc(iGRU)%hruInfo(iHRU)%nSoil
@@ -291,11 +294,12 @@ contains
 
     ! get the index in the file: single HRU
     if(restartFileType==singleHRU)then
-     ixFile = 1  ! use for single HRU restart file
+     !  ixFile = 1  ! use for single HRU restart file
+     ixFile = startGRU
 
     ! get the index in the file: multi HRU
     else
-     ixFile = iHRU_local
+     ixFile = startGRU + iHRU_local - 1
     endif
 
     ! put the data into data structures and check that none of the values are set to nf90_fill_double
@@ -335,7 +339,7 @@ contains
   if(err/=0)then; message=trim(message)//'problem deallocating HRU variable data'; return; endif
 
  end do ! end looping through prognostic variables (iVar)
- 
+
  ! --------------------------------------------------------------------------------------------------------
  ! (2) set number of layers
  ! --------------------------------------------------------------------------------------------------------
@@ -388,20 +392,20 @@ contains
    end do  ! looping through soil layers
   end do  ! looping through HRUs
  end do  ! looping through GRUs
- 
+
  ! --------------------------------------------------------------------------------------------------------
  ! (2) now get the basin variable(s)
  ! --------------------------------------------------------------------------------------------------------
 
  ! get the index in the file: single HRU
  if(restartFileType/=singleHRU)then
- 
+
   ! get dimension of time delay histogram (TDH) from initial conditions file
   err = nf90_inq_dimid(ncID,"tdh",dimID);
   if(err/=nf90_noerr)then
    write(*,*) 'WARNING: routingRunoffFuture is not in the initial conditions file ... using zeros'  ! previously created in var_derive.f90
    err=nf90_noerr    ! reset this err
-   
+
   else
    ! the state file *does* have the basin variable(s), so process them
    err = nf90_inquire_dimension(ncID,dimID,len=nTDH);
@@ -422,19 +426,19 @@ contains
    ndx = (/iLookBVAR%routingRunoffFuture/)   ! array of desired variable indices
    do i = 1,size(ndx)
     iVar = ndx(i)
-  
+
     ! get tdh dimension Id in file (should be 'tdh')
-    err = nf90_inq_dimid(ncID,trim(tdhDimName), dimID); 
+    err = nf90_inq_dimid(ncID,trim(tdhDimName), dimID);
     if(err/=0)then; message=trim(message)//': problem with dimension ids for tdh vars'; return; endif
 
     ! get the tdh dimension length (dimName and dimLen are outputs of this call)
     err = nf90_inquire_dimension(ncID,dimID,dimName,dimLen); call netcdf_err(err,message)
     if(err/=0)then; message=trim(message)//': problem getting the dimension length for tdh vars'; return; endif
-  
+
     ! get tdh-based variable id
     err = nf90_inq_varid(ncID,trim(bvar_meta(iVar)%varName),ncVarID); call netcdf_err(err,message)
     if(err/=0)then; message=trim(message)//': problem with getting basin variable id, var='//trim(bvar_meta(iVar)%varName); return; endif
-   
+
     ! initialize the tdh variable data
     allocate(varData(fileGRU,dimLen),stat=err)
     if(err/=0)then; print*, 'err= ',err; message=trim(message)//'problem allocating GRU variable data'; return; endif
@@ -451,13 +455,13 @@ contains
      ! check whether the first values is set to nf90_fill_double
      if(any(abs(bvarData%gru(iGRU)%var(iVar)%dat(1:nTDH) - nf90_fill_double) < epsilon(varData)))then; err=20; endif
      if(err==20)then; message=trim(message)//"data set to the fill value (name='"//trim(bvar_meta(iVar)%varName)//"')"; return; endif
-    
+
     end do ! end iGRU loop
-   
+
     ! deallocate temporary data array for next variable
     deallocate(varData, stat=err)
     if(err/=0)then; message=trim(message)//'problem deallocating GRU variable data'; return; endif
-   
+
    end do ! end looping through basin variables
   endif  ! end if case for tdh variables being in init. cond. file
  endif  ! end if case for not being a singleHRU run


### PR DESCRIPTION
This fixes a bug in using restart files if you use the `-g startGRU countGRU` flag. Previously the initial conditions were always selected starting at the first index instead of at `startGRU`. Note that this does break the ability to use subsetted restart files.