### PR TITLE
Feature/gru hru id in error

### DIFF
--- a/build/source/engine/run_oneGRU.f90
+++ b/build/source/engine/run_oneGRU.f90
@@ -135,8 +135,8 @@ contains
  logical(lgt)                            :: computeVegFluxFlag     ! flag to indicate if we are computing fluxes over vegetation (.false. means veg is buried with snow)
 
  ! initialize error control
- err=0; message='run_oneGRU/'
-
+ err=0; write(message, '(A24,I0,A2)' ) 'run_oneGRU (gru index = ',gruInfo%gru_nc,')/'
+ 
  ! ----- basin initialization --------------------------------------------------------------------------------------------
 
  ! initialize runoff variables
@@ -194,7 +194,7 @@ contains
                   ! error control
                   err,cmessage)                      ! intent(out):   error control
   if(err/=0)then; err=20; message=trim(message)//trim(cmessage); return; endif
-
+  
   ! update layer numbers that could be changed in run_oneHRU -- needed for model output
   gruInfo%hruInfo(iHRU)%nSnow = nSnow
   gruInfo%hruInfo(iHRU)%nSoil = nSoil

--- a/build/source/engine/run_oneGRU.f90
+++ b/build/source/engine/run_oneGRU.f90
@@ -136,7 +136,7 @@ contains
 
  ! initialize error control
  err=0; write(message, '(A24,I0,A2)' ) 'run_oneGRU (gru index = ',gruInfo%gru_nc,')/'
- 
+
  ! ----- basin initialization --------------------------------------------------------------------------------------------
 
  ! initialize runoff variables
@@ -194,7 +194,7 @@ contains
                   ! error control
                   err,cmessage)                      ! intent(out):   error control
   if(err/=0)then; err=20; message=trim(message)//trim(cmessage); return; endif
-  
+ 
   ! update layer numbers that could be changed in run_oneHRU -- needed for model output
   gruInfo%hruInfo(iHRU)%nSnow = nSnow
   gruInfo%hruInfo(iHRU)%nSoil = nSoil

--- a/build/source/engine/run_oneHRU.f90
+++ b/build/source/engine/run_oneHRU.f90
@@ -140,7 +140,7 @@ contains
  real(dp)          , allocatable   :: zSoilReverseSign(:) ! height at bottom of each soil layer, negative downwards (m)
 
  ! initialize error control
- err=0; message='run_oneHRU/'
+ err=0; write(message, '(A20,I0,A2)' ) 'run_oneHRU (hruId = ',hruId,')/'
  
  ! ----- hru initialization ---------------------------------------------------------------------------------------------
 


### PR DESCRIPTION
Updated the error reporting in routines `run_oneGRU` and `run_oneHRU` to include the index of the GRU in the netcdf file and the hruId. This is helpful when isolating problematic GRUs/HRUs in large domain runs.

Example error before changes:
```
1980  5  1  0  0
 solution method           =            3
data_step                 =       3600.0000000000
totalSoilCompress         =          0.0000000000
scalarTotalSoilLiq        =        909.4334985312
scalarTotalSoilIce        =        313.4928317471
balanceSoilWater0         =       1221.1696585988
balanceSoilWater1         =       1222.9263302783
balanceSoilInflux         =          1.7670322140
balanceSoilBaseflow       =          0.0000000000
balanceSoilDrainage       =          0.0103174598
balanceSoilET             =         -0.1526087002
scalarSoilWatBalError     =          0.1525656256
scalarSoilWatBalError     =          0.0001525656
absConvTol_liquid         =          0.0000100000


FATAL ERROR: run_oneGRU/run_oneHRU/coupled_em/soil hydrology does not balance
```
Example after changes:
```
1980  5  1  0  0
 solution method           =            3
data_step                 =       3600.0000000000
totalSoilCompress         =          0.0000000000
scalarTotalSoilLiq        =        909.4334985312
scalarTotalSoilIce        =        313.4928317471
balanceSoilWater0         =       1221.1696585988
balanceSoilWater1         =       1222.9263302783
balanceSoilInflux         =          1.7670322140
balanceSoilBaseflow       =          0.0000000000
balanceSoilDrainage       =          0.0103174598
balanceSoilET             =         -0.1526087002
scalarSoilWatBalError     =          0.1525656256
scalarSoilWatBalError     =          0.0001525656
absConvTol_liquid         =          0.0000100000


FATAL ERROR: run_oneGRU (gru index = 42915)/run_oneHRU (hruId = 71028528)/coupled_em/soil hydrology does not balance
```

Is this a desirable change?
Are further checks of the code needed?
