### PR TITLE
bugfix of error reporting in coupled_em soil balance check

### DIFF
--- a/build/source/engine/opSplittin.f90
+++ b/build/source/engine/opSplittin.f90
@@ -946,8 +946,19 @@ contains
   ! ==========================================================================================================================================
 
   ! success = exit the coupling loop
-  if(ixCoupling==fullyCoupled .and. .not. failure) exit coupling   ! terminate DO loop early if fullyCoupled returns a solution
-  if(ixCoupling==stateTypeSplit .and. .not. failure) exit coupling ! terminating the DO loop here is cleaner than letting it complete, because in the latter case the coupling loop will end with ixCoupling = nCoupling+1 = 3 (a FORTRAN loop increments the index variable at the end of each iteration and stops the loop if the index > specified stop value). Variable ixCoupling is used for error reporting in coupled_em.f90 in the balance checks and we thus need to make sure ixCoupling is not incremented to be larger than nCoupling. 
+  ! terminate DO loop early if fullyCoupled returns a solution,
+  ! so that the loop does not proceed to ixCoupling = stateTypeSplit
+  if(ixCoupling==fullyCoupled .and. .not. failure) exit coupling
+  
+  ! if we reach stateTypeSplit, terminating the DO loop here is cleaner 
+  ! than letting the loop complete, because in the latter case the coupling 
+  ! loop will end with ixCoupling = nCoupling+1 = 3 (a FORTRAN loop 
+  ! increments the index variable at the end of each iteration and stops 
+  ! the loop if the index > specified stop value). Variable ixCoupling is 
+  ! used for error reporting in coupled_em.f90 in the balance checks and 
+  ! we thus need to make sure ixCoupling is not incremented to be larger 
+  ! than nCoupling.
+  if(ixCoupling==stateTypeSplit .and. .not. failure) exit coupling  
   
  end do coupling ! coupling method
 

--- a/build/source/engine/opSplittin.f90
+++ b/build/source/engine/opSplittin.f90
@@ -481,7 +481,7 @@ contains
   end select  ! operator splitting option
 
   ! state splitting loop
-  stateTypeSplit: do iStateTypeSplit=1,nStateTypeSplit
+  stateTypeSplitLoop: do iStateTypeSplit=1,nStateTypeSplit
 
    !print*, 'iStateTypeSplit, nStateTypeSplit = ', iStateTypeSplit, nStateTypeSplit
 
@@ -935,7 +935,7 @@ contains
     where(ixStateType(ixHydLayer) ==iname_lmpLayer)  ixStateType(ixHydLayer) =iname_matLayer
    endif  ! if modifying state variables for the mass split
 
-  end do stateTypeSplit ! state type splitting loop
+  end do stateTypeSplitLoop ! state type splitting loop
 
   ! check
   !if(ixCoupling/=fullyCoupled)then
@@ -946,8 +946,9 @@ contains
   ! ==========================================================================================================================================
 
   ! success = exit the coupling loop
-  if(ixCoupling==fullyCoupled .and. .not.failure) exit coupling
-
+  if(ixCoupling==fullyCoupled .and. .not. failure) exit coupling   ! terminate DO loop early if fullyCoupled returns a solution
+  if(ixCoupling==stateTypeSplit .and. .not. failure) exit coupling ! terminating the DO loop here is cleaner than letting it complete, because in the latter case the coupling loop will end with ixCoupling = nCoupling+1 = 3 (a FORTRAN loop increments the index variable at the end of each iteration and stops the loop if the index > specified stop value). Variable ixCoupling is used for error reporting in coupled_em.f90 in the balance checks and we thus need to make sure ixCoupling is not incremented to be larger than nCoupling. 
+  
  end do coupling ! coupling method
 
  ! check that all state variables were updated


### PR DESCRIPTION
Incorrect solution method was returned by `opSplittin`, resulting in an incorrect error message in the soil balance check in `coupled_em`.

Also addresses #441 because this fix uses the `stateTypeSplit` variable, inside what was previously called the `stateTypeSplit` DO loop. The loop construct is renamed to `stateTypeSplitLoop`. 

Error message before fix:
```
1980  5  1  0  0
 solution method           =            3
data_step                 =       3600.0000000000
totalSoilCompress         =          0.0000000000
scalarTotalSoilLiq        =        881.7115625650
scalarTotalSoilIce        =        329.8913458868
balanceSoilWater0         =       1209.7726357183
balanceSoilWater1         =       1211.6029084519
balanceSoilInflux         =          1.8391640923
balanceSoilBaseflow       =          0.0000000000
balanceSoilDrainage       =          0.0089130253
balanceSoilET             =         -0.1470989161
scalarSoilWatBalError     =          0.1471205826
scalarSoilWatBalError     =          0.0001471206
absConvTol_liquid         =          0.0000100000

FATAL ERROR: run_oneGRU (gru index = 47131)/run_oneHRU (hruId = 71027547)/coupled_em/soil hydrology does not balance
```
Solution method `3` does not exist; only `1` (fullyCoupled) and `2` (stateTypeSplit) are currently available in `opSplittin.f90`. `opSplittin` returns solution method 3 because the splitting is handled inside a DO loop, and the loop's index variable is used to report the solution method. Fortran increments the loop index at the end of each iteration and terminates the loop if index > stop_value. In the case of solution method `2`, the loop is not terminated early if a solution is found and the index is thus incremented to `3`. This stops the DO loop stops because 3 > 2 but the index stays at the incremented value and thus no longer matches the solution method. This fix prevents this from happening.

Error message after fix:
```
1980  5  1  0  0
 solution method           =            2
data_step                 =       3600.0000000000
totalSoilCompress         =          0.0000000000
scalarTotalSoilLiq        =        881.7115625650
scalarTotalSoilIce        =        329.8913458868
balanceSoilWater0         =       1209.7726357183
balanceSoilWater1         =       1211.6029084519
balanceSoilInflux         =          1.8391640923
balanceSoilBaseflow       =          0.0000000000
balanceSoilDrainage       =          0.0089130253
balanceSoilET             =         -0.1470989161
scalarSoilWatBalError     =          0.1471205826
scalarSoilWatBalError     =          0.0001471206
absConvTol_liquid         =          0.0000100000

FATAL ERROR: run_oneGRU (gru index = 47131)/run_oneHRU (hruId = 71027547)/coupled_em/soil hydrology does not balance
```
