### PR TITLE
cleaned up noah-mp phenology routine and removed check that gave 0 SAI & LAI if below 0.05

### DIFF
--- a/build/source/noah-mp/module_sf_noahmplsm.F
+++ b/build/source/noah-mp/module_sf_noahmplsm.F
@@ -518,35 +518,36 @@ contains
 ! inputs
   INTEGER                , INTENT(IN   ) :: VEGTYP !vegetation type
   INTEGER                , INTENT(IN   ) :: ISURBAN!urban category
-  REAL(rkind)                   , INTENT(IN   ) :: SNOWH  !snow height [m]
-  REAL(rkind)                   , INTENT(IN   ) :: TV     !vegetation temperature (k)
-  REAL(rkind)                   , INTENT(IN   ) :: LAT    !latitude (radians)
+  REAL(rkind)            , INTENT(IN   ) :: SNOWH  !snow height [m]
+  REAL(rkind)            , INTENT(IN   ) :: TV     !vegetation temperature (k)
+  REAL(rkind)            , INTENT(IN   ) :: LAT    !latitude (radians)
   INTEGER                , INTENT(IN   ) :: YEARLEN!Number of days in the particular year
-  REAL(rkind)                   , INTENT(IN   ) :: JULIAN !Julian day of year (fractional) ( 0 <= JULIAN < YEARLEN )
-  real(rkind)                   , INTENT(IN   ) :: TROOT  !root-zone averaged temperature (k)
-  REAL(rkind)                   , INTENT(INOUT) :: LAI    !LAI, unadjusted for burying by snow
-  REAL(rkind)                   , INTENT(INOUT) :: SAI    !SAI, unadjusted for burying by snow
+  REAL(rkind)            , INTENT(IN   ) :: JULIAN !Julian day of year (fractional) ( 0 <= JULIAN < YEARLEN )
+  real(rkind)            , INTENT(IN   ) :: TROOT  !root-zone averaged temperature (k)
+  REAL(rkind)            , INTENT(INOUT) :: LAI    !LAI, unadjusted for burying by snow
+  REAL(rkind)            , INTENT(INOUT) :: SAI    !SAI, unadjusted for burying by snow
 
 ! outputs
-  REAL(rkind)                   , INTENT(OUT  ) :: HTOP   !top of canopy layer (m)
-  REAL(rkind)                   , INTENT(OUT  ) :: ELAI   !leaf area index, after burying by snow
-  REAL(rkind)                   , INTENT(OUT  ) :: ESAI   !stem area index, after burying by snow
-  REAL(rkind)                   , INTENT(OUT  ) :: IGS    !growing season index (0=off, 1=on)
+  REAL(rkind)            , INTENT(OUT  ) :: HTOP   !top of canopy layer (m)
+  REAL(rkind)            , INTENT(OUT  ) :: ELAI   !leaf area index, after burying by snow
+  REAL(rkind)            , INTENT(OUT  ) :: ESAI   !stem area index, after burying by snow
+  REAL(rkind)            , INTENT(OUT  ) :: IGS    !growing season index (0=off, 1=on)
 
 ! locals
 
-  REAL(rkind)                                   :: DB     !thickness of canopy buried by snow (m)
-  REAL(rkind)                                   :: FB     !fraction of canopy buried by snow
-  REAL(rkind)                                   :: SNOWHC !critical snow depth at which short vege
+  REAL(rkind)                            :: DB     !thickness of canopy buried by snow (m)
+  REAL(rkind)                            :: FB     !fraction of canopy buried by snow
+  REAL(rkind)                            :: SNOWHC !critical snow depth at which short vege
                                                    !is fully covered by snow
 
   INTEGER                                :: K       !index
   INTEGER                                :: IT1,IT2 !interpolation months
-  REAL(rkind)                                   :: DAY     !current day of year ( 0 <= DAY < YEARLEN )
-  REAL(rkind)                                   :: WT1,WT2 !interpolation weights
-  REAL(rkind)                                   :: T       !current month (1.00, ..., 12.00)
+  REAL(rkind)                            :: DAY     !current day of year ( 0 <= DAY < YEARLEN )
+  REAL(rkind)                            :: WT1,WT2 !interpolation weights
+  REAL(rkind)                            :: T       !current month (1.00, ..., 12.00)
 ! --------------------------------------------------------------------------------------------------
 
+  ! Interpolate monthly SAI and LAI to daily values
   IF ( DVEG == 1 .or. DVEG == 3 .or. DVEG == 4 ) THEN
 
      IF (LAT >= 0.) THEN
@@ -568,10 +569,17 @@ contains
      LAI = WT1*LAIM(VEGTYP,IT1) + WT2*LAIM(VEGTYP,IT2)
      SAI = WT1*SAIM(VEGTYP,IT1) + WT2*SAIM(VEGTYP,IT2)
   ENDIF
-  IF (SAI < 0.05) SAI = 0.0  ! MB: SAI CHECK
-  IF (LAI < 0.05 .OR. SAI == 0.0) LAI = 0.0  ! MB: LAI CHECK
+  
+  ! Realism check: no leaves without stems
+  IF (SAI == 0.0) LAI = 0.0  
 
-  IF ( ( VEGTYP == ISWATER ) .OR. ( VEGTYP == ISBARREN ) .OR. ( VEGTYP == ISSNOW ) .or. ( VEGTYP == ISURBAN) ) THEN
+  ! Realism check: warn about no stems for vegetated land classes
+  IF ( (SAI == 0.0) .and. ( VEGTYP /= ISWATER ) .and. ( VEGTYP /= ISBARREN ) .and. ( VEGTYP /= ISSNOW ) .and. ( VEGTYP /= ISURBAN) ) THEN
+   write(*,'(A,I3,A)') ' WARNING: module_sf_noahmplsm/PHENOLOGY: Stem Area Index (SAI) = 0.0 may be unrealistic for vegetation type ',VEGTYP,'. Continuing.'
+  ENDIF
+  
+  ! Realism check: no vegetation should exist on certain land classes
+  IF ( ( VEGTYP == ISWATER ) .or. ( VEGTYP == ISBARREN ) .or. ( VEGTYP == ISSNOW ) .or. ( VEGTYP == ISURBAN) ) THEN
      LAI  = 0.
      SAI  = 0.
   ENDIF

--- a/docs/whats-new.md
+++ b/docs/whats-new.md
@@ -2,6 +2,9 @@
 
 This page provides simple, high-level documentation about what has changed in each new release of SUMMA.
 
+## Develop
+- Fixes an unnecessary rounding error on SAI and LAI values in PHENOLOGY routine
+
 ## Version 3.0.4 (pre-release)
 
 - Initial addition of the "What's new" page


### PR DESCRIPTION
Make sure all the relevant boxes are checked (and only check the box if you actually completed the step):

- [ ] partly addresses #479
- [ ] tests passed
- [ ] new tests added
- [ ] science test figures
- [ ] checked that the new code conforms to the [SUMMA coding conventions](https://github.com/NCAR/summa/blob/master/docs/howto/summa_coding_conventions.md)
- [ ] ReleaseNotes entry

## Issue
Noah-MP code includes a check that sets SAI and/or LAI values to 0 if the ever drop below 0.05. This was (presumably) to avoid numerical issues with dividing by small numbers but this does not seem needed in current SUMMA. An undesirable consequence of this check was the potential to get unrealistic SAI and LAI patterns. Example below (copied from #479).

![image](https://user-images.githubusercontent.com/45757529/129452846-19f7a902-813f-4bb6-8fc4-1c96d8300c4e.png)


## Fix
Removed the checks and did some general cleanup of the routine. Martyn and I decided that it would be good to notify the user of potentially unrealistic values so added a warning that triggers if SAI drops to 0 for vegetated land classes. Warning indentation matches indentation: in https://github.com/NCAR/summa/blob/372c3fbeb3825e3b3d635461a8e552f9f0895aec/build/source/netcdf/read_icond.f90#L401

## Tests
Standard test cases partly complete identical and partly not, solely due to differences in LAI values. These are expected to change: 

```
Test   0 - Filename: celia1990_testSumma_timestep.nc                                  - Total difference: 0.0
Test   1 - Filename: colbeck1976-exp1_testSumma_timestep.nc                           - Total difference: 0.0
Test   2 - Filename: colbeck1976-exp2_testSumma_timestep.nc                           - Total difference: 0.0
Test   3 - Filename: colbeck1976-exp3_testSumma_timestep.nc                           - Total difference: 0.0
Test   4 - Filename: millerClay_testSumma_timestep.nc                                 - Total difference: 0.0
Test   5 - Filename: millerLoam_testSumma_timestep.nc                                 - Total difference: 0.0
Test   6 - Filename: millerSand_testSumma_timestep.nc                                 - Total difference: 0.0
Test   7 - Filename: mizoguchi1990_testSumma_timestep.nc                              - Total difference: 0.0
Test   8 - Filename: vanderborght2005_exp1_testSumma_timestep.nc                      - Total difference: 0.0
Test   9 - Filename: vanderborght2005_exp2_testSumma_timestep.nc                      - Total difference: 0.0
Test  10 - Filename: vanderborght2005_exp3_testSumma_timestep.nc                      - Total difference: 0.0
Test  11 - Filename: syntheticHillslope-exp1_testSumma_timestep.nc                    - Total difference: 0.0
Test  12 - Filename: syntheticHillslope-exp2_testSumma_timestep.nc                    - Total difference: 0.0
Test  20 - Filename: storckSite_hedpom9697_timestep.nc                                - Total difference: 0.0
Test  21 - Filename: storckSite_hedpom9798_timestep.nc                                - Total difference: 0.0
Test  22 - Filename: storckSite_storck9697_timestep.nc                                - Total difference: 0.0
Test  23 - Filename: storckSite_storck9798_timestep.nc                                - Total difference: 0.0
Test  24 - Filename: albedoTest_reynoldsConstantDecayRate_timestep.nc                 - Total difference: 0.0
Test  25 - Filename: albedoTest_reynoldsVariableDecayRate_timestep.nc                 - Total difference: 0.0
Test  26 - Filename: albedoTest_senatorConstantDecayRate_timestep.nc                  - Total difference: 0.0
Test  27 - Filename: albedoTest_senatorVariableDecayRate_timestep.nc                  - Total difference: 0.0

Test  13 - Variable: scalarLAI                                                        -       difference: 198.46191961310507
Test  13 - Filename: vegImpactsRad_riparianAspenBeersLaw_timestep.nc                  - Total difference: 198.46191961310507

Test  14 - Variable: scalarLAI                                                        -       difference: 198.46191961310507
Test  14 - Filename: vegImpactsRad_riparianAspenCLM2stream_timestep.nc                - Total difference: 198.46191961310507

Test  15 - Variable: scalarLAI                                                        -       difference: 198.46191961310507
Test  15 - Filename: vegImpactsRad_riparianAspenNLscatter_timestep.nc                 - Total difference: 198.46191961310507

Test  16 - Variable: scalarLAI                                                        -       difference: 198.46191961310507
Test  16 - Filename: vegImpactsRad_riparianAspenUEB2stream_timestep.nc                - Total difference: 198.46191961310507

Test  17 - Variable: scalarLAI                                                        -       difference: 975.6049659438222
Test  17 - Filename: vegImpactsRad_riparianAspenVegParamPerturb_timestep.nc           - Total difference: 975.6049659438222

Test  18 - Variable: scalarLAI                                                        -       difference: 980.9152465977772
Test  18 - Filename: vegImpactsWind_riparianAspenWindParamPerturb_timestep.nc         - Total difference: 980.9152465977772

Test  19 - Variable: scalarLAI                                                        -       difference: 198.46191961310507
Test  19 - Filename: vegImpactsWind_riparianAspenExpWindProfile_timestep.nc           - Total difference: 198.46191961310507

Test  28 - Variable: scalarLAI                                                        -       difference: 54.74999999999987
Test  28 - Filename: vegImpactsTranspire_ballBerry_timestep.nc                        - Total difference: 54.74999999999987

Test  29 - Variable: scalarLAI                                                        -       difference: 54.74999999999987
Test  29 - Filename: vegImpactsTranspire_jarvis_timestep.nc                           - Total difference: 54.74999999999987

Test  30 - Variable: scalarLAI                                                        -       difference: 54.74999999999987
Test  30 - Filename: vegImpactsTranspire_simpleResistance_timestep.nc                 - Total difference: 54.74999999999987

Test  31 - Variable: scalarLAI                                                        -       difference: 273.7499999999995
Test  31 - Filename: vegImpactsTranspire_perturbRoots_timestep.nc                     - Total difference: 273.7499999999995

Test  32 - Variable: scalarLAI                                                        -       difference: 328.7562499033108
Test  32 - Filename: basinRunoff_1dRichards_timestep.nc                               - Total difference: 328.7562499033108

Test  33 - Variable: scalarLAI                                                        -       difference: 1700.0697958055705
Test  33 - Filename: basinRunoff_distributedTopmodel_timestep.nc                      - Total difference: 1700.0697958055705

Test  34 - Variable: scalarLAI                                                        -       difference: 383.5062499033106
Test  34 - Filename: basinRunoff_lumpedTopmodel_timestep.nc                           - Total difference: 383.5062499033106
```

<add more text to investigate why a LAI change doesn't lead to a change in any of the fluxes that are part of the output of the test cases>
