### PR TITLE
Fixed bug where totalET & netRadiation were incorrectly written to output 

### DIFF
--- a/build/source/dshare/flxMapping.f90
+++ b/build/source/dshare/flxMapping.f90
@@ -164,9 +164,9 @@ contains
  flux2state_orig(iLookFLUX%scalarAquiferBaseflow)           = flux2state(state1=iname_matLayer,  state2=integerMissing)
 
  ! derived variables
- flux2state_orig(iLookFLUX%scalarTotalET)                   = flux2state(state1=iname_nrgCanopy, state2=integerMissing)
+ flux2state_orig(iLookFLUX%scalarTotalET)                   = flux2state(state1=iname_nrgCanopy, state2=iname_nrgLayer)
  flux2state_orig(iLookFLUX%scalarTotalRunoff)               = flux2state(state1=iname_matLayer,  state2=integerMissing)
- flux2state_orig(iLookFLUX%scalarNetRadiation)              = flux2state(state1=iname_nrgCanopy, state2=integerMissing)
+ flux2state_orig(iLookFLUX%scalarNetRadiation)              = flux2state(state1=iname_nrgCanopy, state2=iname_nrgLayer)
 
  ! ** copy across flux metadata
  do iVar=1,nFlux

--- a/docs/whats-new.md
+++ b/docs/whats-new.md
@@ -2,6 +2,9 @@
 
 This page provides simple, high-level documentation about what has changed in each new release of SUMMA.
 
+## Develop
+- Fixes a bug that incorrectly writes scalarTotalET and scalarNetRadiation to output in cases where canopy calculations are skipped
+
 ## Version 3.0.4 (pre-release)
 
 - Initial addition of the "What's new" page


### PR DESCRIPTION
Affected variables are scalarTotalET and scalarNetRadiation, which were correctly calculated but incorrectly written to output files on timesteps where no vegetation calculations were performed.

Make sure all the relevant boxes are checked (and only check the box if you actually completed the step):

- [ ] closes #327 , 
       partly addresses #479 , 
       complements #484 
- [ ] tests passed
- [ ] science test figures
- [ ] checked that the new code conforms to the [SUMMA coding conventions](https://github.com/NCAR/summa/blob/master/docs/howto/summa_coding_conventions.md)
- [ ] ReleaseNotes entry

## Issue
In niche cases, variables `scalarTotalET` and `scalarNetRadiation` get calcualted correctly as part of the `opSplittin` routine but not copied from the temporary data structure `flux_temp` (used by `systemSolve` and underlying processes) into the main data structure `flux_data` used to write output files and carry data over between timesteps. This is because these variables were originally only identified as `iname_nrgCanopy` in `flxMapping` which is used to determine which variables to copy from the temporary structure into the main structure, and `iname_nrgCanopy` variables are not copied from `temp` to `data` in cases where no canopy energy calculations are performed. Identifying both variables also as `iname_nrgLayer` ensures that they are copied correctly in all cases.

## Equations
`scalarTotalET`:

https://github.com/NCAR/summa/blob/372c3fbeb3825e3b3d635461a8e552f9f0895aec/build/source/engine/vegNrgFlux.f90#L1441

`scalarNetRadiation`:

https://github.com/NCAR/summa/blob/372c3fbeb3825e3b3d635461a8e552f9f0895aec/build/source/engine/vegNrgFlux.f90#L1442

## Tests
### Standard test cases
I added `scalarTotalET`, `scalarNetRadiation` and their constitutive variables to the standard test case outputs to ensure results remain consistent for these variables. The conditions under which this bug appears are present in 7/34 test cases:

```
Test   0 - Filename celia1990_testSumma_timestep.nc                                  - changes expected on      0 time steps.
Test   1 - Filename colbeck1976-exp1_testSumma_timestep.nc                           - changes expected on      0 time steps.
Test   2 - Filename colbeck1976-exp2_testSumma_timestep.nc                           - changes expected on      0 time steps.
Test   3 - Filename colbeck1976-exp3_testSumma_timestep.nc                           - changes expected on      0 time steps.
Test   4 - Filename millerClay_testSumma_timestep.nc                                 - changes expected on      0 time steps.
Test   5 - Filename millerLoam_testSumma_timestep.nc                                 - changes expected on      0 time steps.
Test   6 - Filename millerSand_testSumma_timestep.nc                                 - changes expected on      0 time steps.
Test   7 - Filename mizoguchi1990_testSumma_timestep.nc                              - changes expected on      0 time steps.
Test   8 - Filename vanderborght2005_exp1_testSumma_timestep.nc                      - changes expected on      0 time steps.
Test   9 - Filename vanderborght2005_exp2_testSumma_timestep.nc                      - changes expected on      0 time steps.
Test  10 - Filename vanderborght2005_exp3_testSumma_timestep.nc                      - changes expected on      0 time steps.
Test  11 - Filename syntheticHillslope-exp1_testSumma_timestep.nc                    - changes expected on  50350 time steps.
Test  12 - Filename syntheticHillslope-exp2_testSumma_timestep.nc                    - changes expected on  50350 time steps.
Test  13 - Filename vegImpactsRad_riparianAspenBeersLaw_timestep.nc                  - changes expected on      0 time steps.
Test  14 - Filename vegImpactsRad_riparianAspenCLM2stream_timestep.nc                - changes expected on      0 time steps.
Test  15 - Filename vegImpactsRad_riparianAspenNLscatter_timestep.nc                 - changes expected on      0 time steps.
Test  16 - Filename vegImpactsRad_riparianAspenUEB2stream_timestep.nc                - changes expected on      0 time steps.
Test  17 - Filename vegImpactsRad_riparianAspenVegParamPerturb_timestep.nc           - changes expected on      0 time steps.
Test  18 - Filename vegImpactsWind_riparianAspenWindParamPerturb_timestep.nc         - changes expected on      0 time steps.
Test  19 - Filename vegImpactsWind_riparianAspenExpWindProfile_timestep.nc           - changes expected on      0 time steps.
Test  20 - Filename storckSite_hedpom9697_timestep.nc                                - changes expected on      0 time steps.
Test  21 - Filename storckSite_hedpom9798_timestep.nc                                - changes expected on      0 time steps.
Test  22 - Filename storckSite_storck9697_timestep.nc                                - changes expected on      0 time steps.
Test  23 - Filename storckSite_storck9798_timestep.nc                                - changes expected on      0 time steps.
Test  24 - Filename albedoTest_reynoldsConstantDecayRate_timestep.nc                 - changes expected on   1946 time steps.
Test  25 - Filename albedoTest_reynoldsVariableDecayRate_timestep.nc                 - changes expected on   1959 time steps.
Test  26 - Filename albedoTest_senatorConstantDecayRate_timestep.nc                  - changes expected on   3035 time steps.
Test  27 - Filename albedoTest_senatorVariableDecayRate_timestep.nc                  - changes expected on   3105 time steps.
Test  28 - Filename vegImpactsTranspire_ballBerry_timestep.nc                        - changes expected on      0 time steps.
Test  29 - Filename vegImpactsTranspire_jarvis_timestep.nc                           - changes expected on      0 time steps.
Test  30 - Filename vegImpactsTranspire_simpleResistance_timestep.nc                 - changes expected on      0 time steps.
Test  31 - Filename vegImpactsTranspire_perturbRoots_timestep.nc                     - changes expected on      0 time steps.
Test  32 - Filename basinRunoff_1dRichards_timestep.nc                               - changes expected on      0 time steps.
Test  33 - Filename basinRunoff_distributedTopmodel_timestep.nc                      - changes expected on  35792 time steps.
Test  34 - Filename basinRunoff_lumpedTopmodel_timestep.nc                           - changes expected on      0 time steps.
```

Test cases complete bit-4-bit identical where expected and deviate in only `scalarTotalET` and/or `scalarNetRadiation` where expected:

```
Test   0 - Filename: celia1990_testSumma_timestep.nc                                  - Total difference: 0.0
Test   1 - Filename: colbeck1976-exp1_testSumma_timestep.nc                           - Total difference: 0.0
Test   2 - Filename: colbeck1976-exp2_testSumma_timestep.nc                           - Total difference: 0.0
Test   3 - Filename: colbeck1976-exp3_testSumma_timestep.nc                           - Total difference: 0.0
Test   4 - Filename: millerClay_testSumma_timestep.nc                                 - Total difference: 0.0
Test   5 - Filename: millerLoam_testSumma_timestep.nc                                 - Total difference: 0.0
Test   6 - Filename: millerSand_testSumma_timestep.nc                                 - Total difference: 0.0
Test   7 - Filename: mizoguchi1990_testSumma_timestep.nc                              - Total difference: 0.0
Test   8 - Filename: vanderborght2005_exp1_testSumma_timestep.nc                      - Total difference: 0.0
Test   9 - Filename: vanderborght2005_exp2_testSumma_timestep.nc                      - Total difference: 0.0
Test  10 - Filename: vanderborght2005_exp3_testSumma_timestep.nc                      - Total difference: 0.0

Test  11 - Variable: scalarNetRadiation                                               -       difference: 1657622.1487927483
Test  11 - Variable: scalarTotalET                                                    -       difference: 0.15835834201014903
Test  11 - Filename: syntheticHillslope-exp1_testSumma_timestep.nc                    - Total difference: 1657622.3071510904

Test  12 - Variable: scalarNetRadiation                                               -       difference: 1682531.8951496314
Test  12 - Variable: scalarTotalET                                                    -       difference: 0.23157308335481688
Test  12 - Filename: syntheticHillslope-exp2_testSumma_timestep.nc                    - Total difference: 1682532.1267227149

Test  13 - Filename: vegImpactsRad_riparianAspenBeersLaw_timestep.nc                  - Total difference: 0.0
Test  14 - Filename: vegImpactsRad_riparianAspenCLM2stream_timestep.nc                - Total difference: 0.0
Test  15 - Filename: vegImpactsRad_riparianAspenNLscatter_timestep.nc                 - Total difference: 0.0
Test  16 - Filename: vegImpactsRad_riparianAspenUEB2stream_timestep.nc                - Total difference: 0.0
Test  17 - Filename: vegImpactsRad_riparianAspenVegParamPerturb_timestep.nc           - Total difference: 0.0
Test  18 - Filename: vegImpactsWind_riparianAspenWindParamPerturb_timestep.nc         - Total difference: 0.0
Test  19 - Filename: vegImpactsWind_riparianAspenExpWindProfile_timestep.nc           - Total difference: 0.0
Test  20 - Filename: storckSite_hedpom9697_timestep.nc                                - Total difference: 0.0
Test  21 - Filename: storckSite_hedpom9798_timestep.nc                                - Total difference: 0.0
Test  22 - Filename: storckSite_storck9697_timestep.nc                                - Total difference: 0.0
Test  23 - Filename: storckSite_storck9798_timestep.nc                                - Total difference: 0.0

Test  24 - Variable: scalarNetRadiation                                               -       difference: 205263.99951329286
Test  24 - Filename: albedoTest_reynoldsConstantDecayRate_timestep.nc                 - Total difference: 205263.99951329286

Test  25 - Variable: scalarNetRadiation                                               -       difference: 202325.35318500453
Test  25 - Filename: albedoTest_reynoldsVariableDecayRate_timestep.nc                 - Total difference: 202325.35318500453

Test  26 - Variable: scalarNetRadiation                                               -       difference: 349072.86124327383
Test  26 - Filename: albedoTest_senatorConstantDecayRate_timestep.nc                  - Total difference: 349072.86124327383

Test  27 - Variable: scalarNetRadiation                                               -       difference: 358963.3451640433
Test  27 - Filename: albedoTest_senatorVariableDecayRate_timestep.nc                  - Total difference: 358963.3451640433

Test  28 - Filename: vegImpactsTranspire_ballBerry_timestep.nc                        - Total difference: 0.0
Test  29 - Filename: vegImpactsTranspire_jarvis_timestep.nc                           - Total difference: 0.0
Test  30 - Filename: vegImpactsTranspire_simpleResistance_timestep.nc                 - Total difference: 0.0
Test  31 - Filename: vegImpactsTranspire_perturbRoots_timestep.nc                     - Total difference: 0.0
Test  32 - Filename: basinRunoff_1dRichards_timestep.nc                               - Total difference: 0.0

Test  33 - Variable: scalarNetRadiation                                               -       difference: 3713424.848170898
Test  33 - Filename: basinRunoff_distributedTopmodel_timestep.nc                      - Total difference: 3713424.848170898

Test  34 - Filename: basinRunoff_lumpedTopmodel_timestep.nc                           - Total difference: 0.0
```


### Additional tests
Using a test case with known periods of zero SAI & LAI, and thus no canopy energy calculations, shows that these fixes lead to correct reporting of `scalarTotalET` and `scalarNetRadiation` in output files. 

![bugfix_scalarTotalET](https://user-images.githubusercontent.com/45757529/130112747-0cd36049-3225-4a4c-88dc-5071430c93a9.png)

![bugfix_scalarNetRadiation](https://user-images.githubusercontent.com/45757529/130112804-cf3c1ba3-a22d-41f7-960a-99481275476b.png)

