### PR TITLE
Added maximum infiltration rate decision

### DIFF
--- a/build/cmake/build.mac.bash
+++ b/build/cmake/build.mac.bash
@@ -5,10 +5,10 @@
 # Actual settings may vary
 
 # Mac Example using MacPorts:
-export FC=/opt/homebrew/bin/gfortran                             # Fortran compiler family
+export FC=/opt/local/bin/gfortran                             # Fortran compiler family
 #export FLAGS_OPT="-flto=1"                                   # -flto=1 is slow to compile, but might want to use
 export LIBRARY_LINKS='-llapack'                               # list of library links
-export SUNDIALS_DIR=/Users/wmk934/Installs/sundials/instdir/
+export SUNDIALS_DIR=../../../sundials/instdir/
 
 cmake -B ../cmake_build -S ../. -DUSE_SUNDIALS=ON -DSPECIFY_LAPACK_LINKS=ON -DCMAKE_BUILD_TYPE=Release
 cmake --build ../cmake_build --target all -j

--- a/build/cmake/build.mac.bash
+++ b/build/cmake/build.mac.bash
@@ -5,10 +5,10 @@
 # Actual settings may vary
 
 # Mac Example using MacPorts:
-export FC=/opt/local/bin/gfortran                             # Fortran compiler family
+export FC=/opt/homebrew/bin/gfortran                             # Fortran compiler family
 #export FLAGS_OPT="-flto=1"                                   # -flto=1 is slow to compile, but might want to use
 export LIBRARY_LINKS='-llapack'                               # list of library links
-export SUNDIALS_DIR=../../../sundials/instdir/
+export SUNDIALS_DIR=/Users/wmk934/Installs/sundials/instdir/
 
 cmake -B ../cmake_build -S ../. -DUSE_SUNDIALS=ON -DSPECIFY_LAPACK_LINKS=ON -DCMAKE_BUILD_TYPE=Release
 cmake --build ../cmake_build --target all -j

--- a/build/source/dshare/data_types.f90
+++ b/build/source/dshare/data_types.f90
@@ -638,6 +638,7 @@ MODULE data_types
    logical(lgt) :: firstSplitOper   ! flag indicating if desire to compute infiltration
    logical(lgt) :: deriv_desired    ! flag to indicate if derivatives are desired
    integer(i4b) :: ixRichards       ! index defining the option for Richards' equation (moisture or mixdform)
+   integer(i4b) :: ixInfRateMax     ! index defining the maximum infiltration rate method (GreenAmpt or topmodel_GA)
    integer(i4b) :: bc_upper         ! index defining the type of boundary conditions
    integer(i4b) :: nRoots           ! number of layers that contain roots
    integer(i4b) :: ixIce            ! index of lowest ice layer
@@ -1718,13 +1719,15 @@ contains
    firstSplitOper         => in_soilLiqFlx % firstSplitOper,                      & ! flag to compute infiltration
    deriv_desired          => in_soilLiqFlx % deriv_desired,                       & ! flag indicating if derivatives are desired
    ixRichards             => model_decisions(iLookDECISIONS%f_Richards)%iDecision,& ! index of the form of Richards' equation
-   ixBcUpperSoilHydrology => model_decisions(iLookDECISIONS%bcUpprSoiH)%iDecision & ! index defining the type of boundary conditions
+   ixBcUpperSoilHydrology => model_decisions(iLookDECISIONS%bcUpprSoiH)%iDecision,& ! index defining the type of boundary conditions
+   ixInfRateMax           => model_decisions(iLookDECISIONS%infRateMax)%iDecision & ! index of the maximum infiltration rate parameterization
   &)
    ! intent(in): model control
    in_surfaceFlx % firstSplitOper = firstSplitOper          ! flag indicating if desire to compute infiltration
    in_surfaceFlx % deriv_desired  = deriv_desired           ! flag indicating if derivatives are desired
    in_surfaceFlx % ixRichards     = ixRichards              ! index defining the form of Richards' equation (moisture or mixdform)
    in_surfaceFlx % bc_upper       = ixBcUpperSoilHydrology  ! index defining the type of boundary conditions (Neumann or Dirichlet)
+   in_surfaceFlx % ixInfRateMax   = ixInfRateMax            ! index defining the maximum infiltration rate parameterization (GreenAmpt or topmodel_GA)
    in_surfaceFlx % nRoots         = nRoots                  ! number of layers that contain roots
    in_surfaceFlx % ixIce          = ixIce                   ! index of lowest ice layer
    in_surfaceFlx % nSoil          = nSoil                   ! number of soil layers

--- a/build/source/dshare/get_ixname.f90
+++ b/build/source/dshare/get_ixname.f90
@@ -97,6 +97,7 @@ contains
   case('snowUnload'      ); get_ixdecisions=iLookDECISIONS%snowUnload  ! choice of parameterization for snow unloading from canopy
   case('nrgConserv'      ); get_ixdecisions=iLookDECISIONS%nrgConserv  ! choice of variable in either energy backward Euler residual or IDA state variable
   case('aquiferIni'      ); get_ixdecisions=iLookDECISIONS%aquiferIni  ! choice of full or empty aquifer at start
+  case('infRateMax'      ); get_ixdecisions=iLookDECISIONS%infRateMax  ! choice of maximum infiltration rate method
   ! get to here if cannot find the variable
   case default
    get_ixdecisions = integerMissing

--- a/build/source/dshare/var_lookup.f90
+++ b/build/source/dshare/var_lookup.f90
@@ -76,6 +76,7 @@ MODULE var_lookup
   integer(i4b)    :: snowDenNew = integerMissing     ! choice of method for new snow density
   integer(i4b)    :: nrgConserv = integerMissing     ! choice of variable in either energy backward Euler residual or IDA state variable
   integer(i4b)    :: aquiferIni = integerMissing     ! choice of full or empty aquifer at start
+  integer(i4b)    :: infRateMax = integerMissing     ! choice of method to determine maximum infiltration rate
 
  endtype iLook_decision
 
@@ -893,7 +894,8 @@ MODULE var_lookup
  type(iLook_decision),public,parameter :: iLookDECISIONS=iLook_decision(  1,  2,  3,  4,  5,  6,  7,  8,  9, 10,&
                                                                          11, 12, 13, 14, 15, 16, 17, 18, 19, 20,&
                                                                          21, 22, 23, 24, 25, 26, 27, 28, 29, 30,&
-                                                                         31, 32, 33, 34, 35, 36, 37, 38, 39, 40)
+                                                                         31, 32, 33, 34, 35, 36, 37, 38, 39, 40,&
+                                                                         41)
  ! named variables: model time
  type(iLook_time),    public,parameter :: iLookTIME     =iLook_time    (  1,  2,  3,  4,  5,  6,  7)
  ! named variables: model forcing data

--- a/build/source/engine/mDecisions.f90
+++ b/build/source/engine/mDecisions.f90
@@ -157,6 +157,7 @@ integer(i4b),parameter,public :: emptyStart           = 327    ! empty aquifer a
 ! look-up values for the infiltration method
 integer(i4b),parameter,public :: GreenAmpt            = 331    ! Green-Ampt
 integer(i4b),parameter,public :: topmodel_GA          = 332    ! Green-Ampt-ish for use with qbaseTopmodel hydraulic conductivity
+integer(i4b),parameter,public :: noInfiltrationExcess = 333    ! No infiltration excess runoff
 ! ----------------------------------------------------------------------------------------------------------- 
 
 contains
@@ -671,6 +672,7 @@ subroutine mDecisions(err,message)
   select case(trim(model_decisions(iLookDECISIONS%infRateMax)%cDecision))
     case('GreenAmpt','notPopulatedYet'); model_decisions(iLookDECISIONS%infRateMax)%iDecision = GreenAmpt   ! Green-Ampt
     case('topmodel_GA'); model_decisions(iLookDECISIONS%infRateMax)%iDecision = topmodel_GA                 ! Green-Ampt with TOPMODEL conductivity rate
+    case('noInfExc'); model_decisions(iLookDECISIONS%infRateMax)%iDecision = noInfiltrationExcess           ! no infiltration excess runoff (saturation excess may still occur)
     case default
       err=10; message=trim(message)//"unknown option for infiltration method [option="//trim(model_decisions(iLookDECISIONS%infRateMax)%cDecision)//"]"; return
   end select

--- a/build/source/engine/soilLiqFlx.f90
+++ b/build/source/engine/soilLiqFlx.f90
@@ -1257,13 +1257,13 @@ contains
       ! define the hydraulic conductivity at depth=depthWettingFront (m s-1)
       hydCondWettingFront =  surfaceSatHydCond ! Green-Ampt assumes homogeneous soil, therefore the whole soil column has the same hydraulic conductivity
       ! define the maximum infiltration rate (m s-1)
-      xMaxInfilRate = hydCondWettingFront * (1 + (1._rkind - depthWettingFront/sum(mLayerDepth)) * wettingFrontSuction/depthWettingFront) ! Ks * (1 + (Md) * S/F)
+      xMaxInfilRate = hydCondWettingFront * (1._rkind + (1._rkind - depthWettingFront/sum(mLayerDepth)) * wettingFrontSuction/depthWettingFront) ! Ks * (1 + (Md) * S/F)
       ! define the derivatives
-      dxMaxInfilRate_dWat(:) = 0 ! Temporary
-      dxMaxInfilRate_dTk(:)  = 0 ! Temporary
+      dxMaxInfilRate_dWat(:) = -hydCondWettingFront*wettingFrontSuction*dDepthWettingFront_dWat(:)/depthWettingFront**2_i4b
+      dxMaxInfilRate_dTk(:)  = -hydCondWettingFront*wettingFrontSuction*dDepthWettingFront_dTk(:)/depthWettingFront**2_i4b
     case(noInfiltrationExcess)
       ! define the hydraulic conductivity at depth=depthWettingFront (m s-1)
-      !hydCondWettingFront =  surfaceSatHydCond ! this is not needed, but unsure if not setting this will cause problems
+      !hydCondWettingFront =  surfaceSatHydCond ! this is not needed for this calculation, but keeping it here in case not setting this will cause unanticipated problems down the line
       ! define the maximum infiltration rate (m s-1)
       xMaxInfilRate = veryBig ! If maximum infiltration is very big we'll never have a rainfall rate that exceeds it, so no infiltration excess
       ! define the derivatives

--- a/docs/whats-new.md
+++ b/docs/whats-new.md
@@ -8,6 +8,7 @@ This page provides simple, high-level documentation about what has changed in ea
     - classes for each flux routine were added to data_types.f90
     - large associate statemements are no longer needed in computFlux (associate blocks are now much shorter)
     - the length of computFlux has been decreased substantially
+- Added a new decision to set maximum infiltration rate method
 
 ### Minor changes
 - Updated SWE balance check in coupled_em for cases where all snow melts in one of the substeps


### PR DESCRIPTION
Make sure all the relevant boxes are checked (and only check the box if you actually completed the step):

- [ ] Closes #xxx (identify the issue associated with this PR)
- [x] Code passes standard test cases (results are either bit-for-bit identical, or differences are explained in the PR comment)
- [x] New tests added (describe which tests were performed to test the changes)
- [x] Science test figures (add figures to PR comment and describe the tests)
- [x] Checked that the new code conforms to the [SUMMA coding conventions](https://github.com/NCAR/summa/blob/master/docs/howto/summa_coding_conventions.md)
- [x] Describe the change in the release notes (use  `./summa/docs/whats-new.md`)

**Note**
Leaving text below as original, but note that default decision got changed to `topmodel_ga` in this commit: https://github.com/CH-Earth/summa/commit/dea20e6ebe2c2d2a9afb09bdbf00bbb8299ff665

Reason: accurate backward compatibility, no results change for older setups using new code.

--

This PR adds a new decision to SUMMA that allows users to specify the method by which variable `xMaxInfilRate` is calculated. Previously this was Green-Ampt-like, and this adds the original Green-Ampt as an option. Previous science results can be kept identical by setting the new decision to use the old equation. Using the new equation will affect science results. See below.

**Overview**

| Decision name | Option name | Description |
|-|-|-|
| infRateMax | GreenAmpt | (Default) Green-Ampt approximation of infiltration rate. Infiltration rate converges to Ks at full saturation. This option will lead to new science results. |
| | topmodel_GA | Green-Ampt modified to work with a non-constant hydraulic conductivity profile. Infiltration rate converges to 0 for `zScale_TOPMODEL` (SUMMA parameter) values > 1; to something close(-ish) to Ks for `zScaleTOPMODEL = 1`; and to something (much) larger than Ks for `zScale_TOPMODEL < 1`.  This is the only option currently implemented in SUMMA. |
| | noInfExc | Sets the maximum infiltration rate to something veryBig, so that we'll never see a rainfall rate that exceeds it and thus effectively have no infiltration excess |

**Reasoning**

- Previously the maximum infiltration rate always used what's now called the `topmodel_GA` approach. The drawback of this is that in typical scenarios (i.e. `zScaleTOPMODEL >= 1`) maximum infiltration rates are at best equal but typically lower than what Green-Ampt would predict (particularly at higher relative saturation of the soil column) and this leads to relatively more surface runoff than what Green-Ampt would give. 
- Green-Ampt is selected as the default, because this is (likely) the more appropriate choice in most typical SUMMA setups (i.e., those with `noXplicit` or `bigBuckt` groundwater - only `qBaseTOPMODEL` should use the `topmodel_GA` infiltration approach). 

**Changes**

- Added a new model decision to support selection of maximum infiltration rate method
- Added a check to require groundwater option `qBaseTOPMODEL` to be used with infiltration method `topmodel_GA`
- Added a warning that combining groundwater decision `bigBucket` with infiltration method `topmodel_GA` is not recommended, but because what's now `topmodel_GA` was SUMMA's behavior before this change I did not want to make it flat out impossible to use older SUMMA setups. Therefore a warning and not an exit.

**Implementation tests**
The standard test cases are not particularly instructive for these changes because (1) we know they won't be identical because we're implementing something new in the physics routine, and (2) because the changes interact heavily with other other soil parameters and the standard test cases do not showcase this behavior as much as needed to understand this particular change. Therefore I used a different test case: real data from an actual catchment where I systematically looped through all `soilTypIndex` values to ensure the tests cover a wide range of soil settings. Details below.

| Test | Test part 1 | Test part 2 | Expected outcome |
| - | - | - | - |
| 1 | `develop_sundials` before PR | New code with `topmodel_GA` active | Identical simulations: meant to test that adding the decision infrastructure did not change code functioning |
| 2 | `develop_sundials` before PR | New code with `GreenAmpt` active | Different simulations: meant to show order of magnitude impact of new max infiltration rate estimation method |
| 3 | `develop_sundials` before PR | New code with `noInfExc` active | Different simulations: meant to show order of magnitude impact of new max infiltration rate estimation method |
| 4 | New code with `qBaseTOPMODEL` and `GreenAmpt` active | n/a | Graceful exit with message that these decisions cannot be combined |
| 5 | New code with `bigBucket` and `topmodel_GA` active | n/a | Warning that combining these decisions is not recommended but run continues | 

**Test 1**
This test is intended to show that after implementing these changes SUMMA can still generate the same results as before. This is the case: 
- First set of plots shows baseline simulations for the 12 soil types, using `bigBucket` for groundwater.
- Second set of plots shows the new simulations with `bigBucket` coupled to the new `topmodel_GA` decision.
- Third set of plots shows that the differences between both are 0.

![test1_outcomes](https://github.com/user-attachments/assets/cb1273b1-6cba-4bb0-8203-cd230c695685)

**Test 2**
This test is intended to show the changes in general hydrograph shape and order of magnitude of differences in `averageRoutedRunoff` simulations, as a result of using the new `GreenAmpt` decision. These are, in most cases, substantial:
- First set of plots shows baseline simulations for the 12 soil types, using `bigBucket` for groundwater.
- Second set of plots shows the new simulations with `bigBucket` coupled to the new `GreenAmpt` decision. `averageRoutedRunoff` is considerably less spiky than in the baseline simulations, as a result of the generally higher maximum infiltration rates estimated by the Green-Ampt method.
- Third set of plots shows that the differences in `averageRoutedRunoff` magnitudes are in the order of `1e-7` for most soil types, which is a comparable order of magnitude to `averageRoutedRunoff` simulated by the baseline configuration.

![test2_outcomes](https://github.com/user-attachments/assets/90a63035-f5b6-43da-9b72-f71aa50ee98c)

**Test 3**
This test is intended to show the changes in general hydrograph shape and order of magnitude of differences in `averageRoutedRunoff` simulations, as a result of using the new `noInfExc` decision These are, in most cases, substantial:
- First set of plots shows baseline simulations for the 12 soil types, using `bigBucket` for groundwater.
- Second set of plots shows the new simulations with `bigBucket` coupled to the new `noInfExc` decision. `averageRoutedRunoff` is considerably less spiky than in the baseline simulations, because we effectively disable infiltration excess runoff in this case.
- Third set of plots shows that the differences in `averageRoutedRunoff` magnitudes are in the order of `1e-7` for most soil types, which is a comparable order of magnitude to `averageRoutedRunoff` simulated by the baseline configuration.

![test3_outcomes](https://github.com/user-attachments/assets/d9272eec-807b-4783-8e0f-96ed3aae1b3c)

**Test 4**
Code exits early as expected:
```
file_master is './settings/SUMMA/experiments/infiltrationRate_decision/filemanager_topmodel_error_trial.txt'.
   1 controlVersion: SUMMA_FILE_MANAGER_V3.0.0

  [..]

  13 decisionsFile: modelDecisions_topmodel_error.txt

  [..]

FATAL ERROR: summa_paramSetup/mDecisions/maximum infiltration rate method must be topmodel_GA when using qbaseTopmodel for groundwater, not GreenAmpt
```
**Test 5**
Code generates warning but continues running as expected:
```
file_master is './settings/SUMMA/experiments/infiltrationRate_decision/filemanager_topmodelGA_soilTypeIndex_1.txt'.

[..]

   9 groundwatr: bigBuckt

[..]

  28 infRateMax: topmodel_GA
startTime: iyyy, im, id, ih, imin = 2000  1  1  0  0
finshTime: iyyy, im, id, ih, imin = 2010 12 31 23  0
 DEPRECATION WARNING: Combining groundwater parametrization bigBucket with maximum infiltration rate method topModel_GA is not recommended. This was the default in SUMMA v3.x.x and below, but is not appropriate for this groundwater option. Please use Green-Ampt instead.
 
[..]

 Created output file: ./simulations/experiment_infiltrationRate_decision/topmodelGA_infiltrationRate_decision_soilTypeIndex_1_day.nc
 Created output file: ./simulations/experiment_infiltrationRate_decision/topmodelGA_infiltrationRate_decision_soilTypeIndex_1_timestep.nc
2000  1  2  0  0
2000  1  3  0  0
```

**Left to add**
Derivatives for the new Green-Ampt option in `soilLiqFlx.f90`. Currently set to zero.