### PR TITLE
Fix snow sublimation bug

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -43,3 +43,5 @@ build/cmake_build
 runinfo.txt
 # OpenWQ source code
 build/source/openwq/openwq
+# vscode related files
+.vscode

--- a/build/source/engine/vegNrgFlux.f90
+++ b/build/source/engine/vegNrgFlux.f90
@@ -1528,7 +1528,8 @@ subroutine aeroResist(&
     ! First, calculate new coordinate system above snow - use these to scale wind profiles and resistances
     ! NOTE: the new coordinate system makes zeroPlaneDisplacement and z0Canopy consistent
     heightCanopyTopAboveSnow = heightCanopyTop - snowDepth
-    heightCanopyBottomAboveSnow = max(heightCanopyBottom - snowDepth, 0.0_rkind)
+    ! Ensure that heightCanopyBottomAboveSnow >= z0Ground + xTolerance
+    heightCanopyBottomAboveSnow = max(heightCanopyBottom - snowDepth, z0Ground + xTolerance)
     select case(ixVegTraits)
       ! Raupach (BLM 1994) "Simplified expressions..."
       case(Raupach_BLM1994)
@@ -1637,7 +1638,7 @@ subroutine aeroResist(&
 
     ! compute the resistance between the surface and canopy air UNDER NEUTRAL CONDITIONS (s m-1)
     ! case 1: assume exponential profile extends from the snow depth plus surface roughness length to the displacement height plus vegetation roughness
-    if (ixWindProfile==exponential .or. heightCanopyBottomAboveSnow<z0Ground+xTolerance) then
+    if (ixWindProfile==exponential) then
       ! compute the neutral ground resistance
       tmp1 = exp(-windReductionFactor* z0Ground/heightCanopyTopAboveSnow)
       tmp2 = exp(-windReductionFactor*(z0Canopy+zeroPlaneDisplacement)/heightCanopyTopAboveSnow)

--- a/docs/whats-new.md
+++ b/docs/whats-new.md
@@ -9,6 +9,7 @@ This page provides simple, high-level documentation about what has changed in ea
     - large associate statemements are no longer needed in computFlux (associate blocks are now much shorter)
     - the length of computFlux has been decreased substantially
 - Added a new decision to set maximum infiltration rate method
+- Bug fix: fixed a problem with snow sublimation due to a bug in transitioning from exponential to log wind profile below canopy.
 
 ### Minor changes
 - Updated SWE balance check in coupled_em for cases where all snow melts in one of the substeps


### PR DESCRIPTION
Make sure all the relevant boxes are checked (and only check the box if you actually completed the step):

- [ ] Closes #xxx (identify the issue associated with this PR)
- [ ] Code passes standard test cases (results are either bit-for-bit identical, or differences are explained in the PR comment)
- [x] New tests added (describe which tests were performed to test the changes)
- [x] Science test figures (add figures to PR comment and describe the tests)
- [x] Checked that the new code conforms to the [SUMMA coding conventions](https://github.com/NCAR/summa/blob/master/docs/howto/summa_coding_conventions.md)
- [x] Describe the change in the release notes (use  `./summa/docs/whats-new.md`)

# Summary of the problem

This PR is fix a bug in the snow sublimation calculations related to the wind profile. Especifically, the bug is noted when the wind profile is transitioned from exponential to log below canopy.
This bug was identified during the SUMMA summer madness when a test case showed substantial snow sublimation for the default model configuration/parameter set. The test case uses `MODIFIED_IGBP_MODIS_NOAH` vegetation lookup table for a `woody savanna` case.

The suggested changes were to ensure that `heightCanopyBottomAboveSnow >= z0Ground + xTolerance` instead of `heightCanopyBottomAboveSnow >= 0` as this caused the potential wind profile to continue to the ground surface (i.e., removing the log profile under canopy).

The change was suggested and validated by @martynpclark.

The modified code resulted in a more realistic snow sublimation compared to the unmodified code (see below for the same default parameter set).
![original](https://github.com/user-attachments/assets/984d1fe6-4255-426a-84b6-0bb80dd2c418)
![aftermod](https://github.com/user-attachments/assets/7be0b9f9-0631-4691-9c52-3053b27f7116)

