### PR TITLE
Bugfix: Smax calculations in FUSE ARNO/VIC and PRMS saturation excess options

### DIFF
--- a/build/source/engine/soilLiqFlx.f90
+++ b/build/source/engine/soilLiqFlx.f90
@@ -1059,10 +1059,11 @@ contains
   associate(&
    nSoil              => in_surfaceFlx % nSoil,              & ! number of soil layers
    scalarTotalSoilLiq => in_surfaceFlx % scalarTotalSoilLiq, & ! total liquid water in the soil column (kg m-2)
-   iLayerHeight       => in_surfaceFlx % iLayerHeight        & ! height at the interface of each layer (m)
+   iLayerHeight       => in_surfaceFlx % iLayerHeight,       & ! height at the interface of each layer (m)
+   theta_sat          => in_surfaceFlx % theta_sat           & ! soil porosity (-)
   &)
-   S1=scalarTotalSoilLiq/iden_water ! total water content in upper FUSE layer (m)
-   S1_max=iLayerHeight(nSoil)       ! max water storage for upper FUSE layer (m)
+   S1=scalarTotalSoilLiq/iden_water       ! total water content in upper FUSE layer (m)
+   S1_max=iLayerHeight(nSoil) * theta_sat ! max water storage for upper FUSE layer (m)
   end associate
 
   ! compute tension water content
@@ -1178,10 +1179,11 @@ contains
   associate(&
    nSoil              => in_surfaceFlx % nSoil,              & ! number of soil layers
    scalarTotalSoilLiq => in_surfaceFlx % scalarTotalSoilLiq, & ! total liquid water in the soil column (kg m-2)
-   iLayerHeight       => in_surfaceFlx % iLayerHeight        & ! height at the interface of each layer (m)
+   iLayerHeight       => in_surfaceFlx % iLayerHeight,       & ! height at the interface of each layer (m)
+   theta_sat          => in_surfaceFlx % theta_sat           & ! soil porosity (-)
   &)
-   S1=scalarTotalSoilLiq/iden_water ! total water content in upper FUSE layer (m)
-   S1_max=iLayerHeight(nSoil)       ! max water storage for upper FUSE layer (m)
+   S1=scalarTotalSoilLiq/iden_water       ! total water content in upper FUSE layer (m)
+   S1_max=iLayerHeight(nSoil) * theta_sat ! max water storage for upper FUSE layer (m)
   end associate
 
   ! compute saturated area


### PR DESCRIPTION
Smax needs to be storage in the soil column (layer depth * porosity), not just soil column depth.

Compiles as expected, and a simple test case (1 month, hourly sims) runs to completion with either modeling decision activated.