### PR TITLE
fix: Initialize unassigned total_soil_depth in soilLiqFlx.f90

### DIFF
--- a/build/source/engine/soilLiqFlx.f90
+++ b/build/source/engine/soilLiqFlx.f90
@@ -1626,6 +1626,9 @@ subroutine update_volFracLiq_derivatives
    ! input-output: surface runoff and infiltration flux (m s-1)
    xMaxInfilRate    => io_surfaceFlx % xMaxInfilRate  & ! maximum infiltration rate (m s-1)
   &)
+   ! compute total soil depth from layer thicknesses
+   total_soil_depth = sum(in_surfaceFlx % mLayerDepth)
+
    ! define the depth to the wetting front (m) and derivatives
    depthWettingFront = (rootZoneLiq/availCapacity)*min(rootingDepth,total_soil_depth)
    if(updateInfil)then


### PR DESCRIPTION
## Summary

- Initialize the local variable `total_soil_depth` in `update_surfaceFlx_liquidFlux_computation_max_infiltration_rate` (soilLiqFlx.f90)
- The variable is declared (line 865) but never assigned, causing undefined behavior
- Computes `total_soil_depth = sum(in_surfaceFlx % mLayerDepth)`, consistent with how `sum(mLayerDepth)` is used inline in the master/develop branches

## Problem

The Green-Ampt and TOPMODEL infiltration formulae divide by `total_soil_depth` (via `depthWettingFront`). When the variable is uninitialized:

- **Linux x86-64 / gfortran 13**: Stack reads as `0.0`, causing `depthWettingFront = 0.0` and `0/0 = NaN` in the infiltration rate. The NaN propagates through the flux vector into `computResid`:
  ```
  FATAL ERROR: .../computResid/NaN in residuals
  Note: The following floating-point exceptions are signalling: IEEE_INVALID_FLAG
  ```
- **macOS / ARM**: The bug is masked because stack memory at that address happens to contain a non-zero value from a previous call frame.

## Diagnosis

Debug prints added around the Green-Ampt computation confirmed:
```
DGA avCap= 0.798  rzLiq= 0.325  rzIce= 0.0
DGA dwf=   0.0    tsd=   0.0     ← total_soil_depth is uninitialized (zero)
DGA-GA Ks= 1.39E-06  wfs= 0.3   xMI= NaN
```

Building with `-finit-real=snan` confirms the variable is never assigned — the entire column 5 of the Jacobian becomes signaling NaN.

## Test plan

- [x] Verified fix on Ubuntu 24.04 / WSL2 / gfortran 13.3.0 with a 3-year SUMMA simulation (Bow at Banff, lumped basin, `infRateMax=GreenAmpt`, `nrgConserv=enthalpyForm`)
- [x] Confirmed `total_soil_depth` value matches expected soil column depth (1.0 m for test domain)
- [x] Simulation completes with "finished simulation successfully"

🤖 Generated with [Claude Code](https://claude.com/claude-code)